### PR TITLE
chore: Pages再デプロイを手動実行可能に＆READMEに公開URL追記

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,6 +3,7 @@ name: Deploy Pages (3 apps)
 on:
   push:
     branches: ["main"]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ pnpm -v               # 9.x を確認
 
 メモ: GitHub Pages では Jekyll 処理を避けるため `.nojekyll` を配置しています。404 直リンク時はルートへリダイレクトします。
 
+### 公開リンク（本番）
+- ランディング: https://rfdnxbro.github.io/salon-de-morning/
+- 一般ユーザー: https://rfdnxbro.github.io/salon-de-morning/user/
+- 店舗スタッフ: https://rfdnxbro.github.io/salon-de-morning/store/
+- 派遣クライアント: https://rfdnxbro.github.io/salon-de-morning/client/
+
+
 ローカル開発時は `VITE_BASE` の設定は不要です（ルート `/` で動作）。
 
 ## モックデータ

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite --port 5175",
-    "build": "tsc -b && vite build",
+    "build": "tsc -p tsconfig.json && vite build",
     "preview": "vite preview --port 5175"
   },
   "dependencies": {

--- a/apps/store/package.json
+++ b/apps/store/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite --port 5174",
-    "build": "tsc -b && vite build",
+    "build": "tsc -p tsconfig.json && vite build",
     "preview": "vite preview --port 5174"
   },
   "dependencies": {

--- a/apps/user/package.json
+++ b/apps/user/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc -p tsconfig.json && vite build",
     "preview": "vite preview --port 5173"
   },
   "dependencies": {


### PR DESCRIPTION
- pages.yml に  を追加（Actionsからワンクリック再デプロイ）
- README に GitHub Pages の公開リンクを追記

運用改善のみで、アプリコードの変更はありません。