### PR TITLE
ci: pnpm version二重指定の衝突を解消

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,8 +28,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Install deps
         run: pnpm install --frozen-lockfile=false


### PR DESCRIPTION
Actionsの  で  を指定しており、 の  と二重指定になってCIが停止していました。\n\n変更:\n-  から  を削除（ の定義に委ねる）\n\nエラー抜粋:\n> Error: Multiple versions of pnpm specified:\n>   - version 9 in the GitHub Action config with the key "version"\n>   - version pnpm@9.0.0 in the package.json with the key "packageManager"\n\nこのPRマージ後、再実行で先に進みます。