### PR TITLE
データ/表示修正: 日付の人間可読化・時分表示・日本語状態・ロゴ/タイトルenv化・ダミースロット20件

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,22 @@
+# ===== Frontend 共通（Vite 用）=====
+# Vite は `VITE_` プレフィックスのみクライアントに露出します
+VITE_SITE_NAME=Salon de Morning
+
+# アプリ別タイトル（任意）
+VITE_TITLE_USER=サロン検索
+VITE_TITLE_STORE=店舗ダッシュボード
+VITE_TITLE_CLIENT=派遣クライアント
+
+# 表示用サブラベル（任意）
+VITE_BRAND_SUBLABEL_USER=一般ユーザー
+VITE_BRAND_SUBLABEL_STORE=店舗スタッフ
+VITE_BRAND_SUBLABEL_CLIENT=クライアント
+
+# GitHub Pages などサブパス配信時のベースパス
+# 例: /salon-de-morning/user
+VITE_BASE=/
+
+# ===== Backend/外部連携（例）=====
 # 例: NEXT_PUBLIC_API_BASE_URL=
 # 例: DATABASE_URL=
 # 例: SENTRY_DSN=
-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,22 @@ Makefile やパッケージスクリプトは自己説明的なターゲット�
 - PR: 背景・目的を記述し、UI 変更はスクリーンショットを添付。該当する Notion 節へのリンクを含める。
 - チェックリスト: CI 通過、テスト更新、挙動変更時はドキュメント更新。
 
+## ブランチ戦略（新機能開発）
+- 基本の流れ: 「ブランチ作成 → 開発 → PR → Merge → `main` へ戻って最新化 → ブランチ削除（ローカル/リモート）」
+- 作業開始前に `main` を最新化する。
+  - `git checkout main && git pull origin main`
+- 新機能ごとにブランチを切る（例: `feature/123-短い説明`）。
+  - `git switch -c feature/<issue-number>-<slug>`
+- 実装し、適切にコミットしてリモートへ初回プッシュ。
+  - `git push -u origin feature/<issue-number>-<slug>`
+- GitHub 上で PR を作成し、レビュワーをアサイン。該当 Notion 節へのリンクを含める。
+- PR が merge されたら、ローカルで `main` に戻り最新を取得。
+  - `git checkout main && git pull origin main`
+- 使い終わったブランチを削除。
+  - ローカル: `git branch -d feature/<issue-number>-<slug>`
+  - リモート: `git push origin --delete feature/<issue-number>-<slug>`
+  - 参照整理（任意）: `git fetch -p`
+
 ## セキュリティ・設定
 - 秘密情報はコミットしない。`.env.local` を使用し、必要キーは `.env.example` で共有。
 - 追加した設定フラグは `docs/config.md` に記録。

--- a/apps/client/index.html
+++ b/apps/client/index.html
@@ -3,11 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>派遣クライアント | 予約一覧</title>
+    <title>Salon de Morning | 派遣クライアント</title>
   </head>
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
   </html>
-

--- a/apps/client/src/components/logo.tsx
+++ b/apps/client/src/components/logo.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export function Logo() {
+  const name = import.meta.env.VITE_SITE_NAME ?? 'Salon de Morning';
+  const sub = import.meta.env.VITE_BRAND_SUBLABEL_CLIENT ?? 'クライアント';
+  return (
+    <div className="inline-flex items-baseline gap-2 select-none">
+      <span className="text-2xl font-extrabold tracking-tight">{name}</span>
+      <span className="text-xs text-muted-foreground">{sub}</span>
+    </div>
+  );
+}
+

--- a/apps/client/src/view.tsx
+++ b/apps/client/src/view.tsx
@@ -1,8 +1,20 @@
 import { reservations, joinReservation } from 'mocks';
+import { useEffect } from 'react';
+import { Logo } from './components/logo';
 import { Table, TableHeader, TableHead, TableRow, TableBody, TableCell } from '@/components/ui/table';
 import { Badge } from '@/components/ui/badge';
 
 export function App() {
+  const site = import.meta.env.VITE_SITE_NAME as string | undefined;
+  const title = (import.meta.env.VITE_TITLE_CLIENT as string | undefined) ?? '派遣クライアント';
+  useEffect(() => {
+    document.title = site ? `${site} | ${title}` : title;
+  }, [site, title]);
+  const statusJa: Record<'draft' | 'confirmed' | 'cancelled', string> = {
+    draft: '下書き',
+    confirmed: '確定',
+    cancelled: '取消'
+  };
   const joined = reservations
     .map(joinReservation)
     .filter((r): r is NonNullable<ReturnType<typeof joinReservation>> => !!r)
@@ -10,7 +22,10 @@ export function App() {
 
   return (
     <div className="mx-auto max-w-4xl p-6">
-      <h1 className="text-2xl font-bold mb-4">予約一覧（派遣クライアント・モック）</h1>
+      <header className="mb-4 flex items-center justify-between">
+        <Logo />
+      </header>
+      <h1 className="text-2xl font-bold mb-4">{title}</h1>
       <Table>
         <TableHeader>
           <TableRow>
@@ -30,11 +45,18 @@ export function App() {
               <TableCell>{store.name}</TableCell>
               <TableCell>{user.name}</TableCell>
               <TableCell>
-                {new Date(slot.startAt).toLocaleString('ja-JP', { timeZone: 'Asia/Tokyo' })}
+                {new Date(slot.startAt).toLocaleString('ja-JP', {
+                  timeZone: 'Asia/Tokyo',
+                  year: 'numeric',
+                  month: '2-digit',
+                  day: '2-digit',
+                  hour: '2-digit',
+                  minute: '2-digit'
+                })}
               </TableCell>
               <TableCell>
                 <Badge variant={reservation.status === 'cancelled' ? 'destructive' : 'secondary'}>
-                  {reservation.status}
+                  {statusJa[reservation.status]}
                 </Badge>
               </TableCell>
             </TableRow>

--- a/apps/client/tsconfig.json
+++ b/apps/client/tsconfig.json
@@ -10,7 +10,7 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "types": ["react", "react-dom"],
+    "types": ["react", "react-dom", "vite/client"],
     "strict": true,
     "baseUrl": ".",
     "paths": {

--- a/apps/client/vite.config.ts
+++ b/apps/client/vite.config.ts
@@ -6,6 +6,7 @@ const base = process.env.VITE_BASE || '/';
 
 export default defineConfig({
   base,
+  envDir: '../../',
   resolve: {
     alias: {
       '@': path.resolve(__dirname, 'src'),

--- a/apps/store/index.html
+++ b/apps/store/index.html
@@ -3,11 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>店舗スタッフ | 予約一覧</title>
+    <title>Salon de Morning | 店舗ダッシュボード</title>
   </head>
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
   </html>
-

--- a/apps/store/src/components/logo.tsx
+++ b/apps/store/src/components/logo.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export function Logo() {
+  const name = import.meta.env.VITE_SITE_NAME ?? 'Salon de Morning';
+  const sub = import.meta.env.VITE_BRAND_SUBLABEL_STORE ?? '店舗スタッフ';
+  return (
+    <div className="inline-flex items-baseline gap-2 select-none">
+      <span className="text-2xl font-extrabold tracking-tight">{name}</span>
+      <span className="text-xs text-muted-foreground">{sub}</span>
+    </div>
+  );
+}
+

--- a/apps/store/src/view.tsx
+++ b/apps/store/src/view.tsx
@@ -1,15 +1,30 @@
 import { reservations, joinReservation } from 'mocks';
+import { useEffect } from 'react';
+import { Logo } from './components/logo';
 import { Table, TableHeader, TableHead, TableRow, TableBody, TableCell } from '@/components/ui/table';
 import { Badge } from '@/components/ui/badge';
 
 export function App() {
+  const site = import.meta.env.VITE_SITE_NAME as string | undefined;
+  const title = (import.meta.env.VITE_TITLE_STORE as string | undefined) ?? '店舗ダッシュボード';
+  useEffect(() => {
+    document.title = site ? `${site} | ${title}` : title;
+  }, [site, title]);
+  const statusJa: Record<'draft' | 'confirmed' | 'cancelled', string> = {
+    draft: '下書き',
+    confirmed: '確定',
+    cancelled: '取消'
+  };
   const joined = reservations
     .map(joinReservation)
     .filter((r): r is NonNullable<ReturnType<typeof joinReservation>> => !!r);
 
   return (
     <div className="mx-auto max-w-4xl p-6">
-      <h1 className="text-2xl font-bold mb-4">予約一覧（店舗スタッフ・モック）</h1>
+      <header className="mb-4 flex items-center justify-between">
+        <Logo />
+      </header>
+      <h1 className="text-2xl font-bold mb-4">{title}</h1>
       <Table>
         <TableHeader>
           <TableRow>
@@ -28,14 +43,25 @@ export function App() {
               <TableCell>{store.name}</TableCell>
               <TableCell>{user.name}</TableCell>
               <TableCell>
-                {new Date(slot.startAt).toLocaleString('ja-JP', { timeZone: 'Asia/Tokyo' })}
+                {new Date(slot.startAt).toLocaleString('ja-JP', {
+                  timeZone: 'Asia/Tokyo',
+                  year: 'numeric',
+                  month: '2-digit',
+                  day: '2-digit',
+                  hour: '2-digit',
+                  minute: '2-digit'
+                })}
               </TableCell>
               <TableCell>
-                {new Date(slot.endAt).toLocaleTimeString('ja-JP', { timeZone: 'Asia/Tokyo' })}
+                {new Date(slot.endAt).toLocaleTimeString('ja-JP', {
+                  timeZone: 'Asia/Tokyo',
+                  hour: '2-digit',
+                  minute: '2-digit'
+                })}
               </TableCell>
               <TableCell>
                 <Badge variant={reservation.status === 'cancelled' ? 'destructive' : 'secondary'}>
-                  {reservation.status}
+                  {statusJa[reservation.status]}
                 </Badge>
               </TableCell>
             </TableRow>

--- a/apps/store/tsconfig.json
+++ b/apps/store/tsconfig.json
@@ -10,7 +10,7 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "types": ["react", "react-dom"],
+    "types": ["react", "react-dom", "vite/client"],
     "strict": true,
     "baseUrl": ".",
     "paths": {

--- a/apps/store/vite.config.ts
+++ b/apps/store/vite.config.ts
@@ -6,6 +6,7 @@ const base = process.env.VITE_BASE || '/';
 
 export default defineConfig({
   base,
+  envDir: '../../',
   resolve: {
     alias: {
       '@': path.resolve(__dirname, 'src'),

--- a/apps/user/index.html
+++ b/apps/user/index.html
@@ -3,11 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>一般ユーザー | 検索</title>
+    <title>Salon de Morning | サロン検索</title>
   </head>
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
   </html>
-

--- a/apps/user/src/App.tsx
+++ b/apps/user/src/App.tsx
@@ -1,9 +1,10 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { stores, slots } from 'mocks';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
+import { Logo } from './components/logo';
 
 export function App() {
   const [q, setQ] = useState('');
@@ -20,7 +21,10 @@ export function App() {
 
   return (
     <div className="mx-auto max-w-3xl p-6">
-      <h1 className="text-2xl font-bold mb-6">サロン検索（モック）</h1>
+      <header className="mb-6 flex items-center justify-between">
+        <Logo />
+      </header>
+      <TitleFromEnv fallback="サロン検索" />
 
       <div className="mb-6 space-y-2">
         <Label htmlFor="q">店舗名で検索</Label>
@@ -51,9 +55,20 @@ export function App() {
                   <ul className="list-disc list-inside text-sm">
                     {next.map((sl) => (
                       <li key={sl.id}>
-                        {new Date(sl.startAt).toLocaleString('ja-JP', { timeZone: 'Asia/Tokyo' })}
+                        {new Date(sl.startAt).toLocaleString('ja-JP', {
+                          timeZone: 'Asia/Tokyo',
+                          year: 'numeric',
+                          month: '2-digit',
+                          day: '2-digit',
+                          hour: '2-digit',
+                          minute: '2-digit'
+                        })}
                         {' '}～{' '}
-                        {new Date(sl.endAt).toLocaleTimeString('ja-JP', { timeZone: 'Asia/Tokyo' })}
+                        {new Date(sl.endAt).toLocaleTimeString('ja-JP', {
+                          timeZone: 'Asia/Tokyo',
+                          hour: '2-digit',
+                          minute: '2-digit'
+                        })}
                         {' '}（定員{sl.capacity}）
                       </li>
                     ))}
@@ -76,4 +91,13 @@ export function App() {
       </div>
     </div>
   );
+}
+
+function TitleFromEnv({ fallback }: { fallback: string }) {
+  const site = import.meta.env.VITE_SITE_NAME as string | undefined;
+  const title = (import.meta.env.VITE_TITLE_USER as string | undefined) ?? fallback;
+  useEffect(() => {
+    document.title = site ? `${site} | ${title}` : title;
+  }, [site, title]);
+  return <h1 className="text-2xl font-bold mb-6">{title}</h1>;
 }

--- a/apps/user/src/components/logo.tsx
+++ b/apps/user/src/components/logo.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export function Logo() {
+  const name = import.meta.env.VITE_SITE_NAME ?? 'Salon de Morning';
+  const sub = import.meta.env.VITE_BRAND_SUBLABEL_USER ?? '一般ユーザー';
+  return (
+    <div className="inline-flex items-baseline gap-2 select-none">
+      <span className="text-2xl font-extrabold tracking-tight">{name}</span>
+      <span className="text-xs text-muted-foreground">{sub}</span>
+    </div>
+  );
+}

--- a/apps/user/tsconfig.json
+++ b/apps/user/tsconfig.json
@@ -10,7 +10,7 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "types": ["react", "react-dom"],
+    "types": ["react", "react-dom", "vite/client"],
     "strict": true,
     "baseUrl": ".",
     "paths": {

--- a/apps/user/vite.config.ts
+++ b/apps/user/vite.config.ts
@@ -7,6 +7,7 @@ const base = process.env.VITE_BASE || '/';
 
 export default defineConfig({
   base,
+  envDir: '../../',
   resolve: {
     alias: {
       '@': path.resolve(__dirname, 'src'),

--- a/packages/mocks/src/data.json
+++ b/packages/mocks/src/data.json
@@ -1,0 +1,39 @@
+{
+  "stores": [
+    { "id": "st_1", "name": "銀座サロン", "code": "GINZA", "address": "東京都中央区", "createdAt": "2025-09-15 12:00:00", "updatedAt": "2025-09-15 12:00:00" },
+    { "id": "st_2", "name": "渋谷サロン", "code": "SHIBUYA", "address": "東京都渋谷区", "createdAt": "2025-09-15 12:00:00", "updatedAt": "2025-09-15 12:00:00" }
+  ],
+  "clients": [
+    { "id": "cl_1", "name": "ABC派遣", "code": "ABC", "address": "東京都千代田区", "createdAt": "2025-09-15 12:00:00", "updatedAt": "2025-09-15 12:00:00" }
+  ],
+  "users": [
+    { "id": "u_1", "name": "山田太郎", "createdAt": "2025-09-15 12:00:00", "updatedAt": "2025-09-15 12:00:00" },
+    { "id": "u_2", "name": "佐藤花子", "createdAt": "2025-09-15 12:00:00", "updatedAt": "2025-09-15 12:00:00" }
+  ],
+  "slots": [
+    { "id": "sl_1",  "storeId": "st_1", "clientId": "cl_1", "startAt": "2025-09-16 09:00:00", "endAt": "2025-09-16 11:00:00", "capacity": 1, "status": "active", "title": "ダミースロット01", "createdAt": "2025-09-15 12:00:00", "updatedAt": "2025-09-15 12:00:00" },
+    { "id": "sl_2",  "storeId": "st_2",                      "startAt": "2025-09-16 13:00:00", "endAt": "2025-09-16 14:00:00", "capacity": 2, "status": "active", "title": "ダミースロット02", "createdAt": "2025-09-15 12:00:00", "updatedAt": "2025-09-15 12:00:00" },
+    { "id": "sl_3",  "storeId": "st_1", "clientId": "cl_1", "startAt": "2025-09-16 15:00:00", "endAt": "2025-09-16 17:00:00", "capacity": 3, "status": "active", "title": "ダミースロット03", "createdAt": "2025-09-15 12:00:00", "updatedAt": "2025-09-15 12:00:00" },
+    { "id": "sl_4",  "storeId": "st_2",                      "startAt": "2025-09-18 10:00:00", "endAt": "2025-09-18 11:00:00", "capacity": 1, "status": "active", "title": "ダミースロット04", "createdAt": "2025-09-15 12:00:00", "updatedAt": "2025-09-15 12:00:00" },
+    { "id": "sl_5",  "storeId": "st_1", "clientId": "cl_1", "startAt": "2025-09-19 12:00:00", "endAt": "2025-09-19 13:00:00", "capacity": 2, "status": "active", "title": "ダミースロット05", "createdAt": "2025-09-15 12:00:00", "updatedAt": "2025-09-15 12:00:00" },
+    { "id": "sl_6",  "storeId": "st_2",                      "startAt": "2025-09-19 16:00:00", "endAt": "2025-09-19 17:00:00", "capacity": 3, "status": "active", "title": "ダミースロット06", "createdAt": "2025-09-15 12:00:00", "updatedAt": "2025-09-15 12:00:00" },
+    { "id": "sl_7",  "storeId": "st_1", "clientId": "cl_1", "startAt": "2025-09-20 09:00:00", "endAt": "2025-09-20 10:00:00", "capacity": 1, "status": "active", "title": "ダミースロット07", "createdAt": "2025-09-15 12:00:00", "updatedAt": "2025-09-15 12:00:00" },
+    { "id": "sl_8",  "storeId": "st_2",                      "startAt": "2025-09-20 14:00:00", "endAt": "2025-09-20 15:00:00", "capacity": 2, "status": "active", "title": "ダミースロット08", "createdAt": "2025-09-15 12:00:00", "updatedAt": "2025-09-15 12:00:00" },
+    { "id": "sl_9",  "storeId": "st_1", "clientId": "cl_1", "startAt": "2025-09-22 11:00:00", "endAt": "2025-09-22 12:00:00", "capacity": 3, "status": "active", "title": "ダミースロット09", "createdAt": "2025-09-15 12:00:00", "updatedAt": "2025-09-15 12:00:00" },
+    { "id": "sl_10", "storeId": "st_2",                      "startAt": "2025-09-23 09:00:00", "endAt": "2025-09-23 10:00:00", "capacity": 1, "status": "active", "title": "ダミースロット10", "createdAt": "2025-09-15 12:00:00", "updatedAt": "2025-09-15 12:00:00" },
+    { "id": "sl_11", "storeId": "st_1", "clientId": "cl_1", "startAt": "2025-09-24 13:00:00", "endAt": "2025-09-24 14:00:00", "capacity": 2, "status": "active", "title": "ダミースロット11", "createdAt": "2025-09-15 12:00:00", "updatedAt": "2025-09-15 12:00:00" },
+    { "id": "sl_12", "storeId": "st_2",                      "startAt": "2025-09-24 15:00:00", "endAt": "2025-09-24 17:00:00", "capacity": 3, "status": "active", "title": "ダミースロット12", "createdAt": "2025-09-15 12:00:00", "updatedAt": "2025-09-15 12:00:00" },
+    { "id": "sl_13", "storeId": "st_1", "clientId": "cl_1", "startAt": "2025-09-24 16:00:00", "endAt": "2025-09-24 17:00:00", "capacity": 1, "status": "active", "title": "ダミースロット13", "createdAt": "2025-09-15 12:00:00", "updatedAt": "2025-09-15 12:00:00" },
+    { "id": "sl_14", "storeId": "st_2",                      "startAt": "2025-09-25 09:00:00", "endAt": "2025-09-25 11:00:00", "capacity": 2, "status": "active", "title": "ダミースロット14", "createdAt": "2025-09-15 12:00:00", "updatedAt": "2025-09-15 12:00:00" },
+    { "id": "sl_15", "storeId": "st_1", "clientId": "cl_1", "startAt": "2025-09-25 11:00:00", "endAt": "2025-09-25 13:00:00", "capacity": 3, "status": "active", "title": "ダミースロット15", "createdAt": "2025-09-15 12:00:00", "updatedAt": "2025-09-15 12:00:00" },
+    { "id": "sl_16", "storeId": "st_2",                      "startAt": "2025-09-25 13:00:00", "endAt": "2025-09-25 15:00:00", "capacity": 1, "status": "active", "title": "ダミースロット16", "createdAt": "2025-09-15 12:00:00", "updatedAt": "2025-09-15 12:00:00" },
+    { "id": "sl_17", "storeId": "st_1", "clientId": "cl_1", "startAt": "2025-09-25 15:00:00", "endAt": "2025-09-25 16:00:00", "capacity": 2, "status": "active", "title": "ダミースロット17", "createdAt": "2025-09-15 12:00:00", "updatedAt": "2025-09-15 12:00:00" },
+    { "id": "sl_18", "storeId": "st_2",                      "startAt": "2025-09-26 10:00:00", "endAt": "2025-09-26 12:00:00", "capacity": 3, "status": "active", "title": "ダミースロット18", "createdAt": "2025-09-15 12:00:00", "updatedAt": "2025-09-15 12:00:00" },
+    { "id": "sl_19", "storeId": "st_1", "clientId": "cl_1", "startAt": "2025-09-27 09:00:00", "endAt": "2025-09-27 10:00:00", "capacity": 1, "status": "active", "title": "ダミースロット19", "createdAt": "2025-09-15 12:00:00", "updatedAt": "2025-09-15 12:00:00" },
+    { "id": "sl_20", "storeId": "st_2",                      "startAt": "2025-09-27 14:00:00", "endAt": "2025-09-27 15:00:00", "capacity": 2, "status": "active", "title": "ダミースロット20", "createdAt": "2025-09-15 12:00:00", "updatedAt": "2025-09-15 12:00:00" }
+  ],
+  "reservations": [
+    { "id": "r_1", "slotId": "sl_1", "userId": "u_1", "status": "confirmed", "createdAt": "2025-09-15 12:00:00", "updatedAt": "2025-09-15 12:00:00" },
+    { "id": "r_2", "slotId": "sl_2", "userId": "u_2", "status": "draft", "createdAt": "2025-09-15 12:00:00", "updatedAt": "2025-09-15 12:00:00" }
+  ]
+}

--- a/packages/mocks/src/data.json.d.ts
+++ b/packages/mocks/src/data.json.d.ts
@@ -1,0 +1,45 @@
+declare module './data.json' {
+  export type RawAudit = { createdAt: string; updatedAt: string };
+  export type RawStore = RawAudit & {
+    id: string;
+    name: string;
+    code: string;
+    address: string;
+  };
+  export type RawClient = RawAudit & {
+    id: string;
+    name: string;
+    code: string;
+    address: string;
+  };
+  export type RawUser = RawAudit & {
+    id: string;
+    name: string;
+  };
+  export type RawSlot = RawAudit & {
+    id: string;
+    storeId: string;
+    clientId?: string;
+    startAt: string;
+    endAt: string;
+    capacity: number;
+    status: 'active' | 'cancelled';
+    title?: string;
+    note?: string;
+  };
+  export type RawReservation = RawAudit & {
+    id: string;
+    slotId: string;
+    userId: string;
+    status: 'draft' | 'confirmed' | 'cancelled';
+    note?: string;
+  };
+  const value: {
+    stores: RawStore[];
+    clients: RawClient[];
+    users: RawUser[];
+    slots: RawSlot[];
+    reservations: RawReservation[];
+  };
+  export default value;
+}

--- a/packages/mocks/src/data.ts
+++ b/packages/mocks/src/data.ts
@@ -1,53 +1,66 @@
 import type { Store, Client, User, Slot, Reservation, JoinedReservation } from './types';
+import data from './data.json';
 
-const now = Date.now();
-const jst = (h: number) => new Date(now + h * 60 * 60 * 1000).getTime();
+// 'YYYY-MM-DD HH:mm:ss'（JST想定）→ epoch(ms)
+const parseJst = (s: string): number => {
+  const m = s.trim().match(/^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2}):(\d{2})$/);
+  if (!m) throw new Error(`Invalid datetime format: ${s}`);
+  const [_, y, mo, d, h, mi, se] = m;
+  const year = Number(y);
+  const month = Number(mo);
+  const day = Number(d);
+  const hour = Number(h);
+  const minute = Number(mi);
+  const second = Number(se);
+  // JSTはUTC+9。UTCに換算するため9時間引く。
+  return Date.UTC(year, month - 1, day, hour - 9, minute, second);
+};
 
-export const stores: Store[] = [
-  { id: 'st_1', name: '銀座サロン', code: 'GINZA', address: '東京都中央区', createdAt: now, updatedAt: now },
-  { id: 'st_2', name: '渋谷サロン', code: 'SHIBUYA', address: '東京都渋谷区', createdAt: now, updatedAt: now }
-];
+const toMs = (v: string | number): number => (typeof v === 'number' ? v : parseJst(v));
 
-export const clients: Client[] = [
-  { id: 'cl_1', name: 'ABC派遣', code: 'ABC', address: '東京都千代田区', createdAt: now, updatedAt: now }
-];
+// 分単位に正規化（秒・ミリ秒のみ切り落とす）
+const trimToMinute = (t: number) => {
+  const d = new Date(t);
+  d.setSeconds(0, 0);
+  return d.getTime();
+};
 
-export const users: User[] = [
-  { id: 'u_1', name: '山田太郎', createdAt: now, updatedAt: now },
-  { id: 'u_2', name: '佐藤花子', createdAt: now, updatedAt: now }
-];
-
-export const slots: Slot[] = [
-  {
-    id: 'sl_1',
-    storeId: 'st_1',
-    clientId: 'cl_1',
-    startAt: jst(24),
-    endAt: jst(25),
-    capacity: 2,
-    status: 'active',
-    title: 'カット/カラー',
-    note: 'スタイリスト指名可',
-    createdAt: now,
-    updatedAt: now
-  },
-  {
-    id: 'sl_2',
-    storeId: 'st_2',
-    startAt: jst(48),
-    endAt: jst(49),
-    capacity: 1,
-    status: 'active',
-    title: 'シャンプーのみ',
-    createdAt: now,
-    updatedAt: now
-  }
-];
-
-export const reservations: Reservation[] = [
-  { id: 'r_1', slotId: 'sl_1', userId: 'u_1', status: 'confirmed', createdAt: now, updatedAt: now },
-  { id: 'r_2', slotId: 'sl_2', userId: 'u_2', status: 'draft', createdAt: now, updatedAt: now }
-];
+// JSON -> 型付きエクスポート（必要に応じて分単位へ正規化）
+export const stores: Store[] = data.stores.map((s) => ({
+  ...s,
+  createdAt: toMs(s.createdAt),
+  updatedAt: toMs(s.updatedAt)
+}));
+export const clients: Client[] = data.clients.map((c) => ({
+  ...c,
+  createdAt: toMs(c.createdAt),
+  updatedAt: toMs(c.updatedAt)
+}));
+export const users: User[] = data.users.map((u) => ({
+  ...u,
+  createdAt: toMs(u.createdAt),
+  updatedAt: toMs(u.updatedAt)
+}));
+export const slots: Slot[] = data.slots.map((s): Slot => ({
+  id: s.id,
+  storeId: s.storeId,
+  clientId: s.clientId,
+  startAt: trimToMinute(toMs(s.startAt)),
+  endAt: trimToMinute(toMs(s.endAt)),
+  capacity: s.capacity,
+  status: s.status as Slot['status'],
+  title: s.title,
+  createdAt: toMs(s.createdAt),
+  updatedAt: toMs(s.updatedAt)
+}));
+export const reservations: Reservation[] = data.reservations.map((r): Reservation => ({
+  id: r.id,
+  slotId: r.slotId,
+  userId: r.userId,
+  status: r.status as Reservation['status'],
+  createdAt: toMs(r.createdAt),
+  updatedAt: toMs(r.updatedAt)
+}));
 
 export function joinReservation(r: Reservation): JoinedReservation | undefined {
   const slot = slots.find((s) => s.id === r.slotId);
@@ -57,4 +70,3 @@ export function joinReservation(r: Reservation): JoinedReservation | undefined {
   const user = users.find((u) => u.id === r.userId)!;
   return { reservation: r, slot, store, client, user };
 }
-


### PR DESCRIPTION
背景 / 目的
- モックデータの日時を人間可読にし、UI側の表示崩れを防ぐ
- フロントの表示表現（時:分、状態日本語、ブランド表記）を整備
- .env(VITE_*) でサイト名/タイトルを外だしし、環境別に切替可能にする

主な変更
- data.json: 日時を 'YYYY-MM-DD HH:mm:ss' (JST) に変更
- packages/mocks/src/data.ts: 文字列日時→epoch(ms)変換、分単位丸め、型厳密化
- apps/*: 時刻の秒を非表示（時:分）、状態を日本語化、ロゴ追加、document.title を env 反映
- .env.example: VITE_SITE_NAME / VITE_TITLE_* / VITE_BRAND_SUBLABEL_* を追記
- slots: 日中帯(09:00–17:00)のダミー20件に更新（60/120分、00分境界）

確認事項
- `tsc --noEmit` が apps/user, store, client で通ることを確認
- 表示例: 2025/09/16 09:00、終了は「10:00」のように秒なし
- 状態: draft→下書き / confirmed→確定 / cancelled→取消

影響範囲
- モックデータ読込部と表示部。API実装時はdata.tsの変換部のみ差し替えで対応可能。

備考
- 追加のルール（休日除外・時間帯変更・完全非重複など）や、共通ロゴコンポーネントのUIパッケージ化は別PRで対応可能です。
