### PR TITLE
feat(admin): 管理アプリの初期セットアップとPagesデプロイ対応

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,11 +6,13 @@ VITE_SITE_NAME=Salon de Morning
 VITE_TITLE_USER=サロン検索
 VITE_TITLE_STORE=店舗ダッシュボード
 VITE_TITLE_CLIENT=派遣クライアント
+VITE_TITLE_ADMIN=管理ダッシュボード
 
 # 表示用サブラベル（任意）
 VITE_BRAND_SUBLABEL_USER=一般ユーザー
 VITE_BRAND_SUBLABEL_STORE=店舗スタッフ
 VITE_BRAND_SUBLABEL_CLIENT=クライアント
+VITE_BRAND_SUBLABEL_ADMIN=管理（社内）
 
 # GitHub Pages などサブパス配信時のベースパス
 # 例: /salon-de-morning/user

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -55,6 +55,13 @@ jobs:
           pnpm --filter @app/client build
           mkdir -p dist-all/client
           cp -r apps/client/dist/* dist-all/client/
+      - name: Build admin
+        env:
+          VITE_BASE: "/${{ github.event.repository.name }}/admin/"
+        run: |
+          pnpm --filter @app/admin build
+          mkdir -p dist-all/admin
+          cp -r apps/admin/dist/* dist-all/admin/
 
       - name: Add root index, 404, and nojekyll
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test lint fmt dev help dev-user dev-store dev-client preview-user preview-store preview-client
+.PHONY: build test lint fmt dev help dev-user dev-store dev-client dev-admin preview-user preview-store preview-client preview-admin
 
 help:
 	@echo "Targets: build test lint fmt dev"
@@ -16,7 +16,7 @@ fmt:
 	@pnpm fmt
 
 dev:
-	@echo "利用可能: dev-user, dev-store, dev-client"
+	@echo "利用可能: dev-user, dev-store, dev-client, dev-admin"
 
 dev-user:
 	@pnpm dev:user
@@ -27,6 +27,9 @@ dev-store:
 dev-client:
 	@pnpm dev:client
 
+dev-admin:
+	@pnpm dev:admin
+
 preview-user:
 	@pnpm preview:user
 
@@ -35,3 +38,6 @@ preview-store:
 
 preview-client:
 	@pnpm preview:client
+
+preview-admin:
+	@pnpm preview:admin

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ pnpm -v               # 9.x を確認
 - フロント: React + Vite（CSR）+ TypeScript `strict` + Tailwind CSS
 - データ: `packages/mocks` の TypeScript モック（外部 API なし）
 - モノレポ: pnpm workspaces
-- デプロイ: GitHub Pages（Actions）/ サブパス `/<repo>/{user,store,client}`
+- デプロイ: GitHub Pages（Actions）/ サブパス `/<repo>/{user,store,client,admin}`
 
 詳細は `docs/adr/0001-tech-stack.md` と `docs/schema.md` を参照してください。
 
@@ -32,14 +32,15 @@ pnpm -v               # 9.x を確認
 - `tests/` 単体テスト（`src/` をミラー）。
 - `docs/` ドキュメント（決定記録・設定含む）。
 - `assets/` 画像や静的アセット。
-- `apps/` SPA 群（`user`/`store`/`client`）。
+- `apps/` SPA 群（`user`/`store`/`client`/`admin`）。
 - `packages/mocks` 型とモックデータ。
 
 ## モノレポ構成（pnpm）
-- `apps/user` 一般ユーザー（CSR, React+Vite+TS+Tailwind）
-- `apps/store` 店舗スタッフ（予約一覧）
-- `apps/client` 派遣クライアントスタッフ（予約一覧）
-- `packages/mocks` モックデータと型
+ - `apps/user` 一般ユーザー（CSR, React+Vite+TS+Tailwind）
+ - `apps/store` 店舗スタッフ（予約一覧）
+ - `apps/client` 派遣クライアントスタッフ（予約一覧）
+ - `apps/admin` 社内スタッフ（ユーザー一覧・クライアント一覧）
+ - `packages/mocks` モックデータと型
 
 ## UI/デザイン
 - 方針: shadcn/ui 互換（CLI は未導入）。Tailwind のデザイントークンと `cva` を採用。
@@ -66,6 +67,7 @@ pnpm -v               # 9.x を確認
 - 一般ユーザー: `make dev-user` → http://localhost:5173
 - 店舗スタッフ: `make dev-store` → http://localhost:5174
 - 派遣クライアント: `make dev-client` → http://localhost:5175
+ - 管理（社内）: `make dev-admin` → http://localhost:5176
 
 3) ビルド/プレビュー
 - ビルド（全アプリ）: `make build`
@@ -77,7 +79,7 @@ pnpm -v               # 9.x を確認
 - テスト: 未設定（MVP 後に追加予定）。
 
 ## デプロイ（GitHub Pages, サブパス配信）
-- `main` への push で GitHub Actions が 3 アプリをビルドし、`/<repo>/{user,store,client}` に配置します。
+- `main` への push で GitHub Actions が 4 アプリをビルドし、`/<repo>/{user,store,client,admin}` に配置します。
 - Vite の `base` はワークフローから `VITE_BASE=/<repo>/<app>/`（末尾スラッシュ必須）を注入します。
 - リポジトリ設定 → Pages → Build and deployment: "GitHub Actions" を選択してください。
 
@@ -86,6 +88,7 @@ pnpm -v               # 9.x を確認
 - 一般ユーザー: `https://<user>.github.io/<repo>/user/`
 - 店舗スタッフ: `https://<user>.github.io/<repo>/store/`
 - 派遣クライアント: `https://<user>.github.io/<repo>/client/`
+ - 管理（社内）: `https://<user>.github.io/<repo>/admin/`
 
 メモ: GitHub Pages では Jekyll 処理を避けるため `.nojekyll` を配置しています。404 直リンク時はルートへリダイレクトします。
 
@@ -94,6 +97,7 @@ pnpm -v               # 9.x を確認
 - 一般ユーザー: https://rfdnxbro.github.io/salon-de-morning/user/
 - 店舗スタッフ: https://rfdnxbro.github.io/salon-de-morning/store/
 - 派遣クライアント: https://rfdnxbro.github.io/salon-de-morning/client/
+ - 管理（社内）: https://rfdnxbro.github.io/salon-de-morning/admin/
 
 
 ローカル開発時は `VITE_BASE` の設定は不要です（ルート `/` で動作）。

--- a/apps/admin/index.html
+++ b/apps/admin/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Salon de Morning | 管理</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+  </html>
+

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@app/admin",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite --port 5176",
+    "build": "tsc -p tsconfig.json && vite build",
+    "preview": "vite preview --port 5176"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "mocks": "workspace:*",
+    "@sdm/ui": "workspace:*",
+    "@radix-ui/react-slot": "^1.0.2",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.462.0",
+    "tailwind-merge": "^2.5.2"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.1",
+    "@types/react": "^18.3.5",
+    "@types/react-dom": "^18.3.0",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.47",
+    "tailwindcss": "^3.4.10",
+    "tailwindcss-animate": "^1.0.7",
+    "typescript": "^5.5.4",
+    "vite": "^5.4.2"
+  }
+}
+

--- a/apps/admin/postcss.config.js
+++ b/apps/admin/postcss.config.js
@@ -1,0 +1,7 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};
+

--- a/apps/admin/src/components/logo.tsx
+++ b/apps/admin/src/components/logo.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export function Logo() {
+  const name = import.meta.env.VITE_SITE_NAME ?? 'Salon de Morning';
+  const sub = import.meta.env.VITE_BRAND_SUBLABEL_ADMIN ?? '管理（社内）';
+  return (
+    <div className="inline-flex items-baseline gap-2 select-none">
+      <span className="text-2xl font-extrabold tracking-tight">{name}</span>
+      <span className="text-xs text-muted-foreground">{sub}</span>
+    </div>
+  );
+}
+

--- a/apps/admin/src/components/ui/badge.tsx
+++ b/apps/admin/src/components/ui/badge.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+const badgeVariants = cva(
+  'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring',
+  {
+    variants: {
+      variant: {
+        default: 'border-transparent bg-primary text-primary-foreground hover:opacity-90',
+        secondary: 'border-transparent bg-secondary text-secondary-foreground',
+        outline: 'text-foreground',
+        destructive: 'border-transparent bg-destructive text-destructive-foreground'
+      }
+    },
+    defaultVariants: {
+      variant: 'default'
+    }
+  }
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return <div className={cn(badgeVariants({ variant }), className)} {...props} />;
+}
+
+export { Badge, badgeVariants };
+

--- a/apps/admin/src/components/ui/button.tsx
+++ b/apps/admin/src/components/ui/button.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground shadow hover:opacity-90',
+        secondary: 'bg-secondary text-secondary-foreground hover:opacity-90',
+        outline: 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        link: 'text-primary underline-offset-4 hover:underline',
+        destructive: 'bg-destructive text-destructive-foreground hover:opacity-90'
+      },
+      size: {
+        default: 'h-9 px-4 py-2',
+        sm: 'h-8 rounded-md px-3',
+        lg: 'h-10 rounded-md px-8',
+        icon: 'h-9 w-9'
+      }
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default'
+    }
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'button';
+    return (
+      <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
+    );
+  }
+);
+Button.displayName = 'Button';
+
+export { Button, buttonVariants };
+

--- a/apps/admin/src/components/ui/card.tsx
+++ b/apps/admin/src/components/ui/card.tsx
@@ -1,0 +1,32 @@
+/// <reference types="react" />
+
+type DivProps = React.HTMLAttributes<HTMLDivElement>;
+
+function cx(...classes: Array<string | undefined>) {
+  return classes.filter(Boolean).join(' ');
+}
+
+export const Card = ({ className, ...props }: DivProps) => (
+  <div className={cx('rounded-lg border bg-card text-card-foreground shadow-sm', className)} {...props} />
+);
+
+export const CardHeader = ({ className, ...props }: DivProps) => (
+  <div className={cx('flex flex-col space-y-1.5 p-6', className)} {...props} />
+);
+
+export const CardTitle = ({ className, ...props }: DivProps) => (
+  <h3 className={cx('text-lg font-semibold leading-none tracking-tight', className)} {...props} />
+);
+
+export const CardDescription = ({ className, ...props }: DivProps) => (
+  <p className={cx('text-sm text-muted-foreground', className)} {...props} />
+);
+
+export const CardContent = ({ className, ...props }: DivProps) => (
+  <div className={cx('p-6 pt-0', className)} {...props} />
+);
+
+export const CardFooter = ({ className, ...props }: DivProps) => (
+  <div className={cx('flex items-center p-6 pt-0', className)} {...props} />
+);
+

--- a/apps/admin/src/components/ui/input.tsx
+++ b/apps/admin/src/components/ui/input.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, type, ...props }, ref) => {
+  return (
+    <input
+      type={type}
+      className={cn(
+        'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
+        className,
+      )}
+      ref={ref}
+      {...props}
+    />
+  );
+});
+Input.displayName = 'Input';
+
+export { Input };
+

--- a/apps/admin/src/components/ui/label.tsx
+++ b/apps/admin/src/components/ui/label.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export interface LabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {}
+
+const Label = React.forwardRef<HTMLLabelElement, LabelProps>(
+  ({ className, ...props }, ref) => (
+    <label
+      ref={ref}
+      className={cn('text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70', className)}
+      {...props}
+    />
+  )
+);
+Label.displayName = 'Label';
+
+export { Label };
+

--- a/apps/admin/src/components/ui/table.tsx
+++ b/apps/admin/src/components/ui/table.tsx
@@ -1,0 +1,33 @@
+/// <reference types="react" />
+
+type DivProps = React.HTMLAttributes<HTMLDivElement>;
+type TableProps = React.TableHTMLAttributes<HTMLTableElement>;
+type THProps = React.ThHTMLAttributes<HTMLTableCellElement>;
+type TRProps = React.HTMLAttributes<HTMLTableRowElement>;
+type TDProps = React.TdHTMLAttributes<HTMLTableCellElement>;
+
+export const Table = (props: TableProps) => (
+  <table className="w-full caption-bottom text-sm" {...props} />
+);
+export const TableHeader = (props: DivProps) => (
+  <thead className="[&_tr]:border-b" {...props} />
+);
+export const TableBody = (props: DivProps) => (
+  <tbody className="[&_tr:last-child]:border-0" {...props} />
+);
+export const TableFooter = (props: DivProps) => (
+  <tfoot className="bg-muted/50 font-medium" {...props} />
+);
+export const TableRow = (props: TRProps) => (
+  <tr className="border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted" {...props} />
+);
+export const TableHead = (props: THProps) => (
+  <th
+    className="h-10 px-2 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0"
+    {...props}
+  />
+);
+export const TableCell = (props: TDProps) => (
+  <td className="p-2 align-middle [&:has([role=checkbox])]:pr-0" {...props} />
+);
+

--- a/apps/admin/src/lib/utils.ts
+++ b/apps/admin/src/lib/utils.ts
@@ -1,0 +1,7 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}
+

--- a/apps/admin/src/main.tsx
+++ b/apps/admin/src/main.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import './styles.css';
+import { App } from './view';
+
+createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);
+

--- a/apps/admin/src/styles.css
+++ b/apps/admin/src/styles.css
@@ -1,0 +1,75 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 222.2 84% 4.9%;
+
+    --muted: 210 40% 96.1%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+
+    --popover: 0 0% 100%;
+    --popover-foreground: 222.2 84% 4.9%;
+
+    --card: 0 0% 100%;
+    --card-foreground: 222.2 84% 4.9%;
+
+    --border: 214.3 31.8% 91.4%;
+    --input: 214.3 31.8% 91.4%;
+    --ring: 215 20.2% 65.1%;
+
+    --primary: 222.2 47.4% 11.2%;
+    --primary-foreground: 210 40% 98%;
+
+    --secondary: 210 40% 96.1%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+
+    --accent: 210 40% 96.1%;
+    --accent-foreground: 222.2 47.4% 11.2%;
+
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+
+    --radius: 0.5rem;
+  }
+
+  .dark {
+    --background: 222.2 84% 4.9%;
+    --foreground: 210 40% 98%;
+
+    --muted: 217.2 32.6% 17.5%;
+    --muted-foreground: 215 20.2% 65.1%;
+
+    --popover: 222.2 84% 4.9%;
+    --popover-foreground: 210 40% 98%;
+
+    --card: 222.2 84% 4.9%;
+    --card-foreground: 210 40% 98%;
+
+    --border: 217.2 32.6% 17.5%;
+    --input: 217.2 32.6% 17.5%;
+    --ring: 212.7 26.8% 83.9%;
+
+    --primary: 210 40% 98%;
+    --primary-foreground: 222.2 47.4% 11.2%;
+
+    --secondary: 217.2 32.6% 17.5%;
+    --secondary-foreground: 210 40% 98%;
+
+    --accent: 217.2 32.6% 17.5%;
+    --accent-foreground: 210 40% 98%;
+
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 210 40% 98%;
+  }
+}
+
+@layer base {
+  * { @apply border-border; }
+  body { @apply bg-background text-foreground; }
+}
+
+html, body, #root { height: 100%; }
+

--- a/apps/admin/src/view.tsx
+++ b/apps/admin/src/view.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useMemo, useState } from 'react';
+import { users, clients } from 'mocks';
+import { Logo } from './components/logo';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Table, TableHeader, TableHead, TableRow, TableBody, TableCell } from '@/components/ui/table';
+
+export function App() {
+  const site = import.meta.env.VITE_SITE_NAME as string | undefined;
+  const title = (import.meta.env.VITE_TITLE_ADMIN as string | undefined) ?? '管理ダッシュボード';
+  useEffect(() => {
+    document.title = site ? `${site} | ${title}` : title;
+  }, [site, title]);
+
+  const [uq, setUq] = useState('');
+  const [cq, setCq] = useState('');
+
+  const filteredUsers = useMemo(() => {
+    const k = uq.trim().toLowerCase();
+    return users.filter((u) => u.name.toLowerCase().includes(k));
+  }, [uq]);
+
+  const filteredClients = useMemo(() => {
+    const k = cq.trim().toLowerCase();
+    return clients.filter((c) =>
+      [c.name, c.code, c.address].some((v) => v.toLowerCase().includes(k)),
+    );
+  }, [cq]);
+
+  return (
+    <div className="mx-auto max-w-5xl p-6 space-y-8">
+      <header className="mb-2 flex items-center justify-between">
+        <Logo />
+      </header>
+      <h1 className="text-2xl font-bold">{title}</h1>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>ユーザー一覧</CardTitle>
+          <CardDescription>モックデータから読み込んだ利用者一覧です。</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="mb-3 space-y-2">
+            <Label htmlFor="uq">名前でフィルタ</Label>
+            <Input id="uq" placeholder="例: 山田" value={uq} onChange={(e) => setUq(e.target.value)} />
+          </div>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>ID</TableHead>
+                <TableHead>名前</TableHead>
+                <TableHead>作成日</TableHead>
+                <TableHead>更新日</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {filteredUsers.map((u) => (
+                <TableRow key={u.id}>
+                  <TableCell>{u.id}</TableCell>
+                  <TableCell>{u.name}</TableCell>
+                  <TableCell>{new Date(u.createdAt).toLocaleString('ja-JP', { timeZone: 'Asia/Tokyo' })}</TableCell>
+                  <TableCell>{new Date(u.updatedAt).toLocaleString('ja-JP', { timeZone: 'Asia/Tokyo' })}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>クライアント一覧</CardTitle>
+          <CardDescription>派遣クライアント（企業）の一覧です。</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="mb-3 space-y-2">
+            <Label htmlFor="cq">名前/コード/住所でフィルタ</Label>
+            <Input id="cq" placeholder="例: ACME / 100-0001" value={cq} onChange={(e) => setCq(e.target.value)} />
+          </div>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>ID</TableHead>
+                <TableHead>企業名</TableHead>
+                <TableHead>コード</TableHead>
+                <TableHead>住所</TableHead>
+                <TableHead>作成日</TableHead>
+                <TableHead>更新日</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {filteredClients.map((c) => (
+                <TableRow key={c.id}>
+                  <TableCell>{c.id}</TableCell>
+                  <TableCell>{c.name}</TableCell>
+                  <TableCell>{c.code}</TableCell>
+                  <TableCell>{c.address}</TableCell>
+                  <TableCell>{new Date(c.createdAt).toLocaleString('ja-JP', { timeZone: 'Asia/Tokyo' })}</TableCell>
+                  <TableCell>{new Date(c.updatedAt).toLocaleString('ja-JP', { timeZone: 'Asia/Tokyo' })}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+

--- a/apps/admin/tailwind.config.ts
+++ b/apps/admin/tailwind.config.ts
@@ -1,0 +1,72 @@
+import type { Config } from 'tailwindcss';
+import animate from 'tailwindcss-animate';
+
+export default {
+  darkMode: ['class'],
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    container: {
+      center: true,
+      padding: '2rem',
+      screens: { '2xl': '1400px' },
+    },
+    extend: {
+      colors: {
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))',
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))',
+        },
+        destructive: {
+          DEFAULT: 'hsl(var(--destructive))',
+          foreground: 'hsl(var(--destructive-foreground))',
+        },
+        muted: {
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))',
+        },
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))',
+        },
+        popover: {
+          DEFAULT: 'hsl(var(--popover))',
+          foreground: 'hsl(var(--popover-foreground))',
+        },
+        card: {
+          DEFAULT: 'hsl(var(--card))',
+          foreground: 'hsl(var(--card-foreground))',
+        },
+      },
+      borderRadius: {
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)',
+      },
+      keyframes: {
+        'accordion-down': {
+          from: { height: '0' },
+          to: { height: 'var(--radix-accordion-content-height)' },
+        },
+        'accordion-up': {
+          from: { height: 'var(--radix-accordion-content-height)' },
+          to: { height: '0' },
+        },
+      },
+      animation: {
+        'accordion-down': 'accordion-down 0.2s ease-out',
+        'accordion-up': 'accordion-up 0.2s ease-out',
+      },
+    },
+  },
+  plugins: [animate],
+} satisfies Config;
+

--- a/apps/admin/tsconfig.json
+++ b/apps/admin/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["react", "react-dom", "vite/client"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"],
+      "@sdm/ui": ["../../packages/ui/index.ts"]
+    },
+    "strict": true
+  },
+  "include": ["src"]
+}

--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vite';
+import path from 'node:path';
+import react from '@vitejs/plugin-react';
+
+// GitHub Pages サブパス配信のため、VITE_BASE（例: /<repo>/admin）を利用
+const base = process.env.VITE_BASE || '/';
+
+export default defineConfig({
+  base,
+  envDir: '../../',
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+  plugins: [react()],
+});
+

--- a/docs/config.md
+++ b/docs/config.md
@@ -11,11 +11,13 @@
 - `VITE_TITLE_USER` 例: `サロン検索`
 - `VITE_TITLE_STORE` 例: `店舗ダッシュボード`
 - `VITE_TITLE_CLIENT` 例: `派遣クライアント`
+- `VITE_TITLE_ADMIN` 例: `管理ダッシュボード`
   - 各アプリの画面タイトル（`document.title` の接尾）
 
 - `VITE_BRAND_SUBLABEL_USER` 例: `一般ユーザー`
 - `VITE_BRAND_SUBLABEL_STORE` 例: `店舗スタッフ`
 - `VITE_BRAND_SUBLABEL_CLIENT` 例: `クライアント`
+- `VITE_BRAND_SUBLABEL_ADMIN` 例: `管理（社内）`
   - ロゴ右側に小さく表示するサブラベル
 
 - `VITE_BASE` 例: `/salon-de-morning/user/`

--- a/package.json
+++ b/package.json
@@ -6,10 +6,12 @@
     "dev:user": "pnpm --filter @app/user dev",
     "dev:store": "pnpm --filter @app/store dev",
     "dev:client": "pnpm --filter @app/client dev",
+    "dev:admin": "pnpm --filter @app/admin dev",
     "build": "pnpm -r --workspace-concurrency=1 build",
     "preview:user": "pnpm --filter @app/user preview",
     "preview:store": "pnpm --filter @app/store preview",
     "preview:client": "pnpm --filter @app/client preview",
+    "preview:admin": "pnpm --filter @app/admin preview",
     "lint": "echo 'ESLintは未設定（必要なら追加）'",
     "fmt": "prettier --write . || echo 'Prettier未インストール'",
     "test": "echo 'テストは未設定（MVP後に追加）'"


### PR DESCRIPTION
## 背景 / 目的
- 管理者向けSPA（apps/admin）を追加し、社内オペレーション画面の土台を用意する。
- GitHub Pages（Actions）で `/<repo>/admin/` に配信できるようワークフローを拡張する。
- 仕様・用語は Notion を参照: https://www.notion.so/2557e05887d680619916c4496bdafc54

## 変更概要
- `apps/admin` を追加（React + Vite + TS + Tailwind）
  - タイトル/サブラベルを `.env.example` に追加（`VITE_TITLE_ADMIN`/`VITE_BRAND_SUBLABEL_ADMIN`）
  - `vite.config.ts` で `VITE_BASE` を考慮（サブパス配信）
- GitHub Actions を更新し、admin のビルド/配置を追加
- README を更新（ローカル起動、プレビュー、公開URL の追記）
- Makefile に `dev-admin`/`preview-admin` を追加

## 影響範囲
- Pages 配信構成に admin が追加されます（既存 user/store/client へ影響なし）
- 新機能の追加であり、既存アプリの挙動変更はありません

## 動作確認
- ルートで `pnpm install`
- `make dev-admin` で http://localhost:5176 が表示されること
- Actions 実行後、`https://<user>.github.io/<repo>/admin/` に配信されること

## セキュリティ
- 追加の秘密情報はありません（`.env.example` のみ更新）

## ドキュメント / Notion
- Notion 仕様: https://www.notion.so/2557e05887d680619916c4496bdafc54
- 設定フラグ: `docs/config.md` に admin 用キーを記載済み

## チェックリスト
- [ ] CI が通過する
- [ ] 必要なテストの追加/更新
- [ ] 挙動変更に伴うドキュメント更新
