### PR TITLE
chore(CD): indexにadminリンク追加＋404のadmin対応

### DIFF
--- a/assets/404.html
+++ b/assets/404.html
@@ -10,7 +10,7 @@
     if (parts.length >= 2) {
       var repo = '/' + parts[0];
       var app = parts[1];
-      if (app === 'user' || app === 'store' || app === 'client') {
+      if (app === 'user' || app === 'store' || app === 'client' || app === 'admin') {
         var target = repo + '/' + app + '/';
         location.replace(target);
         return;
@@ -24,4 +24,3 @@
     }
   })();
 </script>
-

--- a/assets/index.html
+++ b/assets/index.html
@@ -19,8 +19,8 @@
       <li><a href="./user/">一般ユーザー（/user/）</a></li>
       <li><a href="./store/">店舗スタッフ（/store/）</a></li>
       <li><a href="./client/">派遣クライアント（/client/）</a></li>
+      <li><a href="./admin/">管理（社内）（/admin/）</a></li>
     </ul>
-    <p class="note">GitHub Pages のプロジェクトサイト（/<code>&lt;repo&gt;</code>/）配信です。ブックマークは末尾スラッシュ付き <code>/user/</code> などを推奨します。</p>
+    <p class="note">GitHub Pages のプロジェクトサイト（/<code>&lt;repo&gt;</code>/）配信です。ブックマークは末尾スラッシュ付き <code>/user/</code> / <code>/store/</code> / <code>/client/</code> / <code>/admin/</code> を推奨します。</p>
   </body>
   </html>
-


### PR DESCRIPTION
## 背景 / 目的
- GitHub Pages のプロジェクトルート（`assets/index.html`）から admin への導線が欠けていたため追加。
- 直接 `/<repo>/admin` へアクセスした際に 404 から正規パスへ戻すため、リダイレクト対象に `admin` を含める。
- 仕様参照: https://www.notion.so/2557e05887d680619916c4496bdafc54

## 変更概要
- `assets/index.html`: `./admin/` へのリンクを追加
- `assets/404.html`: `admin` をリダイレクト対象に追加

## 動作確認
- GitHub Pages ルート: https://rfdnxbro.github.io/salon-de-morning/
  - 一覧に「管理（社内）」リンクが表示され、クリックで `.../admin/` に遷移する
- 直接アクセス: https://rfdnxbro.github.io/salon-de-morning/admin （末尾スラッシュ無し）
  - 404 から `.../admin/` にリダイレクトされる

## 影響範囲 / リスク
- 既存 user/store/client への影響はありません
- 静的アセットのみの変更でビルド影響は軽微

## チェックリスト
- [ ] CI 通過
- [ ] 必要に応じて README のリンク一覧を更新
