### PR TITLE
ユーザー向けコピーの簡素化

### DIFF
--- a/apps/user/src/app/user/dashboard/page.tsx
+++ b/apps/user/src/app/user/dashboard/page.tsx
@@ -39,120 +39,121 @@ export function DashboardPage() {
   }, [storeSummaries]);
 
   return (
-    <div className="grid gap-10" aria-labelledby="dashboard-heading">
-      <header className="space-y-3" aria-live="polite">
-        <h1 id="dashboard-heading" className="text-3xl font-bold text-foreground md:text-4xl">
-          今日のサマリー
-        </h1>
-        <p className="text-lg leading-relaxed text-muted-foreground md:text-xl">
-          ご利用予定や空き状況をひと目で確認できます。気になるサロンは大きなボタンからすぐに絞り込み可能です。
-        </p>
-      </header>
-
-      <section aria-label="主要指標" className="grid gap-6 md:grid-cols-3">
-        <Card className="border-none bg-card/95 shadow-soft">
-          <CardHeader className="gap-3">
-            <CardDescription className="text-base font-semibold text-muted-foreground md:text-lg">
-              予約可能なサロン
-            </CardDescription>
-            <CardTitle className="text-4xl text-primary md:text-5xl">{stats.activeSalons} 箇所</CardTitle>
-          </CardHeader>
-          <CardContent className="text-base text-muted-foreground md:text-lg">
-            全 {stats.totalSalons} 箇所のうち、現在予約を受け付けているサロンの数です。
-          </CardContent>
-        </Card>
-
-        <Card className="border-none bg-card/95 shadow-soft">
-          <CardHeader className="gap-3">
-            <CardDescription className="text-base font-semibold text-muted-foreground md:text-lg">
-              空き枠
-            </CardDescription>
-            <CardTitle className="text-4xl text-primary md:text-5xl">{stats.upcomingSlots} 枠</CardTitle>
-          </CardHeader>
-          <CardContent className="text-base text-muted-foreground md:text-lg">
-            直近で予約可能な枠数です。予約手続きは余裕を持って進められます。
-          </CardContent>
-        </Card>
-
-        <Card className="border-none bg-card/95 shadow-soft">
-          <CardHeader className="gap-3">
-            <CardDescription className="text-base font-semibold text-muted-foreground md:text-lg">
-              ご自身の予約
-            </CardDescription>
-            <CardTitle className="text-4xl text-primary md:text-5xl">
-              {stats.upcomingReservations} 件
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="text-base text-muted-foreground md:text-lg">
-            これから訪問予定の予約件数です。変更が必要な場合は一覧から操作できます。
-          </CardContent>
-        </Card>
-      </section>
-
-      <section aria-label="直近のおすすめ" className="grid gap-6 md:grid-cols-[1.1fr_0.9fr]">
-        <Card className="border-none bg-primary/10 shadow-soft">
-          <CardHeader className="gap-3">
-            <CardDescription className="text-base font-semibold text-primary md:text-lg">
-              次のおすすめ枠
-            </CardDescription>
-            <CardTitle className="text-3xl text-primary md:text-4xl">
+    <div className="flex flex-col gap-12" aria-labelledby="dashboard-heading">
+      <header className="flex flex-col gap-8" aria-live="polite">
+        <div className="flex flex-col gap-5 rounded-[2rem] border border-primary/15 bg-primary/5 p-6 lg:p-8">
+          <h1 id="dashboard-heading" className="text-[2rem] font-bold leading-tight text-primary lg:text-[2.4rem]">
+            今日のご様子とおすすめ行動
+          </h1>
+          <p className="text-lg leading-relaxed text-primary/80 lg:text-xl">
+            今日把握したい情報をこの画面に集約しました。気になる項目を順番に確認してください。
+          </p>
+        </div>
+        <div className="flex flex-col gap-5 rounded-[2rem] border border-accent/30 bg-accent/10 p-6 lg:p-8">
+          <h2 className="text-xl font-semibold text-foreground lg:text-2xl">次のおすすめ行動</h2>
+          <div className="space-y-3 rounded-[1.75rem] border border-accent/40 bg-white/80 p-5 text-accent-foreground">
+            <p className="text-sm font-semibold uppercase tracking-[0.18em] text-accent-foreground/80">
+              次の空き枠
+            </p>
+            <p className="text-3xl font-bold lg:text-[2.2rem]">
               {nextSlot
                 ? `${fullDateFormatter.format(nextSlot.slot.startAt)} 受付`
-                : '現在予約枠を調整中です'}
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4 text-base text-primary/90 md:text-lg">
+                : '現在枠を調整中です'}
+            </p>
             {nextSlot ? (
-              <>
+              <div className="space-y-2 text-base lg:text-lg">
                 <p>
                   会場: <span className="font-semibold">{nextSlot.storeName}</span>
                 </p>
                 <p>
                   終了予定: <span className="font-semibold">{timeFormatter.format(nextSlot.slot.endAt)}</span>
                 </p>
-              </>
+              </div>
             ) : (
-              <p>最新の空き枠が入り次第お知らせします。</p>
+              <p className="text-base text-muted-foreground lg:text-lg">登録次第お知らせします。</p>
             )}
-            <div className="flex flex-col gap-3 md:flex-row">
-              <Button asChild size="lg" className="w-full justify-center">
-                <Link to="../salons" aria-label="サロン一覧ページを開く">
-                  近くのサロンを探す
-                  <ArrowRight className="ml-2 h-6 w-6" aria-hidden="true" />
-                </Link>
-              </Button>
-              <Button asChild size="lg" variant="outline" className="w-full justify-center">
-                <Link to="../reservations" aria-label="予約一覧ページを開く">
-                  予約を確認・変更
-                  <ArrowRight className="ml-2 h-6 w-6" aria-hidden="true" />
-                </Link>
-              </Button>
-            </div>
+          </div>
+          <div className="flex flex-col gap-3">
+            <Button asChild size="lg" className="w-full justify-center">
+              <Link to="../salons" aria-label="サロン一覧ページを開く">
+                近くのサロンを探す
+                <ArrowRight className="ml-2 h-6 w-6" aria-hidden="true" />
+              </Link>
+            </Button>
+            <Button asChild size="lg" variant="outline" className="w-full justify-center">
+              <Link to="../reservations" aria-label="予約一覧ページを開く">
+                予約を確認・変更
+                <ArrowRight className="ml-2 h-6 w-6" aria-hidden="true" />
+              </Link>
+            </Button>
+          </div>
+        </div>
+      </header>
+
+      <section aria-label="主要指標" className="flex flex-col gap-6">
+        <DashboardStat
+          label="予約可能なサロン"
+          value={`${stats.activeSalons} 箇所`}
+          description="現在予約受付中の拠点数です。"
+        />
+        <DashboardStat
+          label="空き枠"
+          value={`${stats.upcomingSlots} 枠`}
+          description="直近で予約できる枠数です。"
+        />
+        <DashboardStat
+          label="ご自身の予約"
+          value={`${stats.upcomingReservations} 件`}
+          description="今後のご予約件数です。"
+        />
+      </section>
+
+      <section aria-label="直近のご予約" className="flex flex-col gap-6">
+        <Card className="rounded-[2rem] border border-primary/20 bg-card/95 shadow-soft">
+          <CardHeader className="gap-4">
+            <CardDescription className="text-lg font-semibold text-primary lg:text-xl">
+              直近のおすすめ枠
+            </CardDescription>
+            <CardTitle className="text-3xl text-foreground lg:text-[2.2rem]">
+              {nextSlot
+                ? `${fullDateFormatter.format(nextSlot.slot.startAt)} に空きあり`
+                : '空き枠は現在調整中です'}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4 text-base text-muted-foreground lg:text-lg">
+            {nextSlot ? (
+              <p>現地スタッフが体調確認まで対応します。ゆとりを持ってお越しください。</p>
+            ) : (
+              <p>登録され次第、メールまたはLINEでご案内します。</p>
+            )}
+            <p className="rounded-2xl bg-muted/40 px-4 py-3 text-sm text-muted-foreground lg:text-base">
+              体調に不安があれば事前にお電話ください。
+            </p>
           </CardContent>
         </Card>
 
-        <Card className="border-none bg-card/95 shadow-soft">
+        <Card className="rounded-[2rem] border border-muted bg-muted/30 shadow-soft">
           <CardHeader className="gap-3">
-            <CardDescription className="text-base font-semibold text-muted-foreground md:text-lg">
+            <CardDescription className="text-lg font-semibold text-muted-foreground lg:text-xl">
               直近のご予約
             </CardDescription>
-            <CardTitle className="text-2xl text-foreground md:text-3xl">
+            <CardTitle className="text-2xl text-foreground lg:text-3xl">
               {upcomingReservations.length > 0 ? '安心してご来場ください' : '現在予定はありません'}
             </CardTitle>
           </CardHeader>
-          <CardContent className="space-y-4 text-base text-muted-foreground md:text-lg">
+          <CardContent className="space-y-4 text-base text-muted-foreground lg:text-lg">
             {upcomingReservations.length > 0 ? (
               <ol className="space-y-3" aria-live="polite">
                 {upcomingReservations.map((reservation) => (
                   <li
                     key={reservation.id}
-                    className="flex flex-col gap-2 rounded-2xl border-2 border-border bg-muted/40 px-4 py-3"
+                    className="flex flex-col gap-2 rounded-[1.75rem] border border-border bg-card/90 px-4 py-4"
                   >
-                    <div className="flex items-start justify-between gap-3">
-                      <p className="text-lg font-semibold text-foreground md:text-xl">
+                    <div className="flex flex-col gap-2">
+                      <p className="text-lg font-semibold text-foreground lg:text-xl">
                         {reservation.storeName}
                       </p>
-                      <Badge variant="secondary" className="text-base">
+                      <Badge variant="secondary" className="w-fit text-base">
                         {reservation.statusLabel}
                       </Badge>
                     </div>
@@ -160,18 +161,38 @@ export function DashboardPage() {
                       {fullDateFormatter.format(reservation.startAt)} ～{' '}
                       {timeFormatter.format(reservation.endAt)}
                     </p>
-                    <p className="text-sm text-muted-foreground md:text-base">
-                      受付スタッフがサポートします。困りごとは当日でもご相談ください。
-                    </p>
+                    <p className="text-sm text-muted-foreground/90 lg:text-base">当日はスタッフがフォローします。</p>
                   </li>
                 ))}
               </ol>
             ) : (
-              <p>予約がまだ無い方は、サロン一覧からお好きな拠点を選んでお申し込みください。</p>
+              <p className="text-base text-muted-foreground lg:text-lg">ご予約がまだ無い方はサロン一覧をご確認ください。</p>
             )}
           </CardContent>
         </Card>
       </section>
     </div>
+  );
+}
+
+interface DashboardStatProps {
+  label: string;
+  value: string;
+  description: string;
+}
+
+function DashboardStat({ label, value, description }: DashboardStatProps) {
+  return (
+    <Card className="rounded-[2rem] border border-primary/15 bg-white/85 shadow-soft">
+      <CardHeader className="gap-4">
+        <CardDescription className="text-base font-semibold text-primary/90 lg:text-lg">
+          {label}
+        </CardDescription>
+        <CardTitle className="text-4xl text-primary lg:text-[3rem]">{value}</CardTitle>
+      </CardHeader>
+      <CardContent className="text-base leading-relaxed text-muted-foreground lg:text-lg">
+        {description}
+      </CardContent>
+    </Card>
   );
 }

--- a/apps/user/src/app/user/layout.tsx
+++ b/apps/user/src/app/user/layout.tsx
@@ -1,9 +1,61 @@
 import { useEffect, useMemo } from 'react';
 import { NavLink, Outlet, useLocation } from 'react-router-dom';
+import { LifeBuoy, MessageCircle, Phone, ShieldCheck, UsersRound, type LucideIcon } from 'lucide-react';
+import { Button } from '@/components/ui/button';
 import { Logo } from '@/components/logo';
 import { cn } from '@/lib/utils';
 import { loadUserData, type UserDataBundle } from './data';
-import { getRouteMeta, resolveRouteKey, userRoutes, type UserRouteKey } from './navigation';
+import {
+  getRouteMeta,
+  resolveRouteKey,
+  userRoutes,
+  type UserRouteKey,
+  type UserRouteMeta,
+} from './navigation';
+
+const assurancePoints = [
+  {
+    icon: ShieldCheck,
+    title: '医師とつながる安心体制',
+    description: '現役医師と看護スタッフが待機し、当日の体調確認もその場で共有できます。',
+  },
+  {
+    icon: UsersRound,
+    title: 'ご家族と一緒に使える',
+    description: '予約内容はご家族にも共有可能。代理操作や付き添いの相談もオンラインで完了。',
+  },
+  {
+    icon: LifeBuoy,
+    title: '困ったらすぐ相談',
+    description: 'スタッフが電話やLINEで状況を伺い、必要な手続きを一緒に進めます。',
+  },
+] as const;
+
+const supportPhoneNumber = import.meta.env.VITE_SUPPORT_PHONE ?? '050-1234-5678';
+const supportLineUrl = import.meta.env.VITE_SUPPORT_LINE_URL ?? 'https://line.me/R/ti/p/placeholder';
+const supportLineNote =
+  import.meta.env.VITE_SUPPORT_LINE_NOTE ?? 'ご家族と一緒に利用可能／夜間は折り返し連絡となります';
+
+const supportChannels = [
+  {
+    id: 'support-phone',
+    icon: Phone,
+    label: 'お電話',
+    value: supportPhoneNumber,
+    note: '平日 8:00～17:00／通話無料',
+    actionLabel: '電話をかける',
+    href: toTelHref(supportPhoneNumber),
+  },
+  {
+    id: 'support-line',
+    icon: MessageCircle,
+    label: 'LINE 相談',
+    value: 'スタッフとすぐにつながります',
+    note: supportLineNote,
+    actionLabel: 'LINEで相談する',
+    href: supportLineUrl,
+  },
+] as const;
 
 const updatedAtFormatter = new Intl.DateTimeFormat('ja-JP', {
   timeZone: 'Asia/Tokyo',
@@ -24,51 +76,163 @@ export function UserLayout() {
   const updatedAtLabel = updatedAtFormatter.format(data.lastUpdatedAt);
 
   return (
-    <div className="relative min-h-screen pb-16">
-      <div className="mx-auto flex min-h-screen max-w-5xl flex-col gap-12 px-6 py-10 md:gap-16 md:px-12">
-        <header className="flex flex-col gap-6" aria-label="サービスのご案内">
-          <Logo />
-          <p className="text-lg font-medium leading-relaxed text-muted-foreground md:text-xl">
-            朝の時間に医療・生活支援を受けられる「サロン de モーニング」。ご自宅から無理なく通える拠点を探し、安心して予約まで完結できます。
-          </p>
-          <div className="flex flex-col gap-3 rounded-3xl bg-card/90 p-6 text-base text-foreground shadow-soft md:flex-row md:items-center md:justify-between md:text-lg">
-            <p className="font-semibold text-foreground">最新データ</p>
-            <p className="text-muted-foreground">
-              {updatedAtLabel} 時点での情報です。操作はゆっくり進めていただけます。
-            </p>
+    <div className="relative min-h-screen pb-24">
+      <div className="mx-auto flex min-h-screen max-w-6xl flex-col gap-12 px-6 py-12 lg:gap-16 lg:px-10">
+        <header className="flex flex-col gap-10 rounded-[2.5rem] bg-card/95 p-8 shadow-soft lg:p-12" aria-label="サービスのご案内">
+          <div className="flex flex-col gap-8">
+            <Logo />
+            <div className="space-y-5 text-balance">
+              <h1 className="text-[2.25rem] font-extrabold leading-snug text-foreground lg:text-[2.75rem]">
+                朝のひとときに、医療・生活の相談をまとめて完結。
+              </h1>
+              <p className="text-lg font-medium leading-relaxed text-muted-foreground lg:text-xl">
+                「サロン de モーニング」は、移動が大変な方でも通いやすい近所の拠点で、
+                医療相談と生活支援を受けられる地域密着サービスです。
+              </p>
+            </div>
+            <section aria-label="安心してご利用いただくための3つの特徴" className="flex flex-col gap-4">
+              {assurancePoints.map(({ icon: Icon, title, description }) => (
+                <article
+                  key={title}
+                  className="flex flex-col gap-3 rounded-[2rem] border-2 border-primary/15 bg-primary/5 px-5 py-6 text-left shadow-soft/60"
+                >
+                  <Icon className="h-10 w-10 text-primary" aria-hidden="true" />
+                  <h2 className="text-xl font-semibold text-foreground lg:text-2xl">{title}</h2>
+                  <p className="text-base leading-relaxed text-muted-foreground lg:text-lg">{description}</p>
+                </article>
+              ))}
+            </section>
           </div>
+          <section className="flex flex-col gap-6 rounded-[2rem] bg-gradient-to-br from-primary/12 via-card to-primary/5 p-6 lg:p-8" aria-label="サポートと最新情報">
+            <div className="space-y-4">
+              <p className="text-sm font-semibold uppercase tracking-[0.14em] text-primary/80">
+                最新のお知らせ
+              </p>
+            </div>
+            <div className="space-y-4 rounded-[1.75rem] border border-primary/20 bg-white/80 p-5 text-sm text-muted-foreground shadow-soft">
+              <p className="text-base font-semibold text-primary/90 lg:text-lg">
+                ご不安なときはすぐスタッフにつながります
+              </p>
+              <div className="flex flex-col gap-3">
+                {supportChannels.map((channel) => (
+                  <SupportChannel key={channel.id} {...channel} />
+                ))}
+              </div>
+              <p className="text-xs text-muted-foreground/80">
+                ※医療に関する緊急の際は、直接かかりつけ医または救急へご連絡ください。
+              </p>
+            </div>
+          </section>
         </header>
 
-        <nav
-          aria-label="主要メニュー"
-          className="grid gap-4 md:grid-cols-3"
-        >
+        <nav aria-label="主要メニュー" className="flex flex-col gap-5">
           {userRoutes.map((route) => (
-            <NavLink
-              key={route.key}
-              to={route.to}
-              className={({ isActive }) =>
-                cn(
-                  'group flex flex-col gap-2 rounded-3xl border-2 px-6 py-5 no-underline transition-all duration-200',
-                  'focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background',
-                  'min-h-[3.25rem] bg-card/80 shadow-soft hover:-translate-y-0.5 hover:border-primary/70 hover:bg-primary/5',
-                  isActive
-                    ? 'border-primary text-primary'
-                    : 'border-border text-foreground',
-                )
-              }
-            >
-              <span className="text-xl font-semibold md:text-2xl">{route.label}</span>
-              <span className="text-base text-muted-foreground md:text-lg">{route.description}</span>
-            </NavLink>
+            <MenuCard key={route.key} route={route} />
           ))}
         </nav>
 
-        <main className="flex-1">
+        <main className="flex-1 rounded-[2.5rem] bg-card/90 p-6 shadow-soft lg:p-10">
           <Outlet context={data} />
         </main>
       </div>
     </div>
+  );
+}
+
+interface SupportChannelConfig {
+  id: string;
+  icon: LucideIcon;
+  label: string;
+  value: string;
+  note: string;
+  actionLabel: string;
+  href: string;
+}
+
+interface SupportChannelProps extends SupportChannelConfig {}
+
+function SupportChannel({ id, icon: Icon, label, value, note, actionLabel, href }: SupportChannelProps) {
+  const noteId = `${id}-note`;
+  const labelId = `${id}-label`;
+  const isExternalLink = href.startsWith('http');
+
+  return (
+    <article
+      className="flex flex-col gap-3 rounded-2xl border border-border/60 bg-muted/40 px-4 py-4"
+      aria-labelledby={labelId}
+      aria-describedby={noteId}
+    >
+      <Icon className="h-8 w-8 text-primary" aria-hidden="true" />
+      <div className="space-y-1">
+        <p id={labelId} className="text-sm font-semibold text-foreground lg:text-base">
+          {label}
+        </p>
+        <p className="text-lg font-bold text-foreground lg:text-xl">{value}</p>
+      </div>
+      <Button
+        asChild
+        size="lg"
+        className="w-full justify-center"
+        variant="primary"
+        aria-describedby={noteId}
+      >
+        <a
+          href={href}
+          target={isExternalLink ? '_blank' : undefined}
+          rel={isExternalLink ? 'noopener noreferrer' : undefined}
+        >
+          {actionLabel}
+        </a>
+      </Button>
+      <p id={noteId} className="text-xs text-muted-foreground/80 lg:text-sm">
+        {note}
+      </p>
+    </article>
+  );
+}
+
+function toTelHref(input: string): string {
+  const normalized = input.replace(/[^0-9+]/g, '');
+  return normalized ? `tel:${normalized}` : 'tel:';
+}
+
+interface MenuCardProps {
+  route: UserRouteMeta;
+}
+
+function MenuCard({ route }: MenuCardProps) {
+  const { accent, icon: Icon, key, label, description, to } = route;
+
+  return (
+    <NavLink
+      to={to}
+      aria-describedby={`${key}-description`}
+      className={({ isActive }) =>
+        cn(
+          'group flex flex-col gap-4 rounded-[2rem] border-2 px-6 py-6 no-underline transition-all duration-200',
+          'focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-ring/60 focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+          'min-h-[9rem] bg-card/85 shadow-soft hover:-translate-y-1',
+          accent === 'primary' && 'hover:border-primary/70 hover:bg-primary/8',
+          accent === 'secondary' && 'hover:border-secondary/80 hover:bg-secondary/12',
+          accent === 'neutral' && 'hover:border-muted-foreground/40 hover:bg-muted/30',
+          isActive
+            ? accent === 'primary'
+              ? 'border-primary bg-primary/10 text-primary'
+              : accent === 'secondary'
+                ? 'border-secondary bg-secondary/20 text-primary'
+                : 'border-border bg-muted/30 text-primary'
+            : 'border-border text-foreground',
+        )
+      }
+    >
+      <Icon className="h-10 w-10 text-primary" aria-hidden="true" />
+      <div className="flex flex-col gap-2">
+        <span className="text-2xl font-bold lg:text-[2rem]">{label}</span>
+        <span id={`${key}-description`} className="text-base text-muted-foreground lg:text-lg">
+          {description}
+        </span>
+      </div>
+    </NavLink>
   );
 }
 

--- a/apps/user/src/app/user/navigation.ts
+++ b/apps/user/src/app/user/navigation.ts
@@ -1,10 +1,15 @@
 export type UserRouteKey = 'dashboard' | 'salons' | 'reservations';
 
+import type { LucideIcon } from 'lucide-react';
+import { CalendarCheck2, HeartPulse, MapPin } from 'lucide-react';
+
 export interface UserRouteMeta {
   key: UserRouteKey;
   label: string;
   description: string;
   to: string;
+  icon: LucideIcon;
+  accent: 'primary' | 'secondary' | 'neutral';
 }
 
 export const userRoutes: readonly UserRouteMeta[] = [
@@ -13,18 +18,24 @@ export const userRoutes: readonly UserRouteMeta[] = [
     label: 'ダッシュボード',
     description: '今日の予定やおすすめ情報を確認できます',
     to: 'dashboard',
+    icon: HeartPulse,
+    accent: 'primary',
   },
   {
     key: 'salons',
     label: 'サロン一覧',
     description: '近くのサロンや空き状況を確認できます',
     to: 'salons',
+    icon: MapPin,
+    accent: 'secondary',
   },
   {
     key: 'reservations',
     label: '予約一覧',
     description: '過去と今後の予約をまとめて確認できます',
     to: 'reservations',
+    icon: CalendarCheck2,
+    accent: 'neutral',
   },
 ] as const;
 

--- a/apps/user/src/app/user/reservations/page.tsx
+++ b/apps/user/src/app/user/reservations/page.tsx
@@ -24,20 +24,31 @@ export function ReservationsPage() {
   }, [reservationSummaries]);
 
   return (
-    <div className="grid gap-8" aria-labelledby="reservation-heading">
-      <header className="space-y-4">
-        <h1 id="reservation-heading" className="text-3xl font-bold text-foreground md:text-4xl">
-          予約一覧
+    <div className="flex flex-col gap-10" aria-labelledby="reservation-heading">
+      <header className="space-y-6 rounded-[2rem] border border-primary/15 bg-primary/5 p-6 lg:p-8">
+        <h1 id="reservation-heading" className="text-[2.1rem] font-bold text-primary lg:text-[2.5rem]">
+          予約一覧（ご来場予定の確認）
         </h1>
-        <p className="text-lg leading-relaxed text-muted-foreground md:text-xl">
-          日程の変更やキャンセルの相談は、各カードの担当スタッフに直接お伝えください。色だけでなくラベルでも状態を表記しています。
+        <p className="text-lg leading-relaxed text-primary/80 lg:text-xl">
+          会場や担当者をひと目で確認できます。ラベル表示で状態が分かります。
         </p>
+        <div className="flex flex-col gap-4">
+          <div className="rounded-[1.75rem] border border-primary/20 bg-white/85 p-4 text-base text-muted-foreground lg:text-lg">
+            <p className="font-semibold text-primary">変更したいときは電話またはLINEでご連絡ください。</p>
+          </div>
+          <div className="rounded-[1.75rem] border border-accent/20 bg-accent/10 p-4 text-base text-muted-foreground lg:text-lg">
+            <p className="font-semibold text-accent-foreground">ご来場は受付時間の10分前を目安にお願いします。</p>
+          </div>
+          <div className="rounded-[1.75rem] border border-muted bg-muted/30 p-4 text-base text-muted-foreground lg:text-lg">
+            <p className="font-semibold text-muted-foreground">代理で操作する場合はメモ欄に共有事項を残してください。</p>
+          </div>
+        </div>
       </header>
 
-      <section aria-label="これからの予約" className="grid gap-4">
-        <h2 className="text-2xl font-semibold text-foreground md:text-3xl">これからの予約</h2>
+      <section aria-label="これからの予約" className="flex flex-col gap-5">
+        <h2 className="text-2xl font-semibold text-foreground lg:text-3xl">これからの予約</h2>
         {upcoming.length > 0 ? (
-          <ol className="grid gap-4">
+          <ol className="flex flex-col gap-5">
             {upcoming.map((reservation) => (
               <li key={reservation.id}>
                 <ReservationCard kind="upcoming" item={reservation} />
@@ -45,16 +56,16 @@ export function ReservationsPage() {
             ))}
           </ol>
         ) : (
-          <p className="rounded-3xl border-2 border-dashed border-border bg-muted/20 px-6 py-8 text-center text-lg text-muted-foreground md:text-xl">
+          <p className="rounded-[2rem] border-2 border-dashed border-border bg-muted/30 px-6 py-10 text-center text-lg text-muted-foreground lg:text-xl">
             直近の予約はありません。気になるサロンがあれば一覧からご予約いただけます。
           </p>
         )}
       </section>
 
-      <section aria-label="これまでの予約" className="grid gap-4">
-        <h2 className="text-2xl font-semibold text-foreground md:text-3xl">これまでの予約</h2>
+      <section aria-label="これまでの予約" className="flex flex-col gap-5">
+        <h2 className="text-2xl font-semibold text-foreground lg:text-3xl">これまでの予約</h2>
         {past.length > 0 ? (
-          <ol className="grid gap-4">
+          <ol className="flex flex-col gap-5">
             {past.map((reservation) => (
               <li key={reservation.id}>
                 <ReservationCard kind="past" item={reservation} />
@@ -62,7 +73,7 @@ export function ReservationsPage() {
             ))}
           </ol>
         ) : (
-          <p className="text-lg text-muted-foreground md:text-xl">
+          <p className="text-lg text-muted-foreground lg:text-xl">
             過去の利用履歴はまだありません。訪問が完了するとこちらに表示されます。
           </p>
         )}
@@ -81,39 +92,39 @@ function ReservationCard({ item, kind }: ReservationCardProps) {
     item.tone === 'positive'
       ? 'border-primary/60 bg-primary/10'
       : item.tone === 'attention'
-        ? 'border-accent/60 bg-accent/10'
-        : 'border-border bg-card/95';
+        ? 'border-accent/60 bg-accent/12'
+        : 'border-border/60 bg-card/90';
 
   return (
     <Card
       className={cn(
-        'flex flex-col gap-4 rounded-3xl border-2 px-6 py-5 shadow-soft transition-colors',
+        'flex flex-col gap-5 rounded-[2rem] border-2 px-6 py-6 shadow-soft transition-colors',
         toneClass,
       )}
     >
-      <CardHeader className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+      <CardHeader className="flex flex-col gap-4">
         <div className="space-y-2">
-          <CardTitle className="text-2xl text-foreground md:text-3xl">{item.storeName}</CardTitle>
-          <CardDescription className="text-lg text-muted-foreground md:text-xl">
+          <CardTitle className="text-2xl text-foreground lg:text-[2.1rem]">{item.storeName}</CardTitle>
+          <CardDescription className="text-lg text-muted-foreground lg:text-xl">
             {dateRangeFormatter.format(item.startAt)} ～ {dateRangeFormatter.format(item.endAt)}
           </CardDescription>
         </div>
-        <Badge variant="secondary" className="text-base md:text-lg">
+        <Badge variant="secondary" className="rounded-full px-4 py-1 text-base lg:text-lg">
           状態: {item.statusLabel}
         </Badge>
       </CardHeader>
-      <CardContent className="space-y-3 text-base text-muted-foreground md:text-lg">
+      <CardContent className="space-y-4 text-base text-muted-foreground lg:text-lg">
         {item.slotTitle && <p>メニュー: {item.slotTitle}</p>}
         <p>利用者: {item.userName}</p>
         {item.clientName && <p>担当医療機関: {item.clientName}</p>}
         {item.note && <p>メモ: {item.note}</p>}
         {kind === 'upcoming' ? (
-          <p className="text-sm text-muted-foreground md:text-base">
-            当日は校閲済みチェックリストをスタッフがサポートします。ご不安な点は前日までにご連絡ください。
+          <p className="rounded-[1.5rem] bg-white/70 px-4 py-3 text-sm text-muted-foreground lg:text-base">
+            ご不安な点は前日までにお気軽にご相談ください。
           </p>
         ) : (
-          <p className="text-sm text-muted-foreground md:text-base">
-            ご利用ありがとうございます。次回のご希望があればサロンスタッフまでお知らせください。
+          <p className="rounded-[1.5rem] bg-muted/40 px-4 py-3 text-sm text-muted-foreground lg:text-base">
+            次回のご希望があればスタッフまでお知らせください。
           </p>
         )}
       </CardContent>

--- a/apps/user/src/app/user/salons/page.tsx
+++ b/apps/user/src/app/user/salons/page.tsx
@@ -29,90 +29,105 @@ export function SalonsPage() {
   );
 
   return (
-    <div className="grid gap-8" aria-labelledby="salon-heading">
-      <header className="space-y-4">
-        <h1 id="salon-heading" className="text-3xl font-bold text-foreground md:text-4xl">
-          サロン一覧
-        </h1>
-        <p className="text-lg leading-relaxed text-muted-foreground md:text-xl">
-          ご自宅から通いやすいサロンをお選びください。各枠はスタッフのサポート付きで、必要に応じて付き添いも手配できます。
-        </p>
+    <div className="flex flex-col gap-10" aria-labelledby="salon-heading">
+      <header className="space-y-6 rounded-[2rem] border border-primary/15 bg-primary/5 p-6 lg:p-8">
+        <div className="space-y-3">
+          <h1 id="salon-heading" className="text-[2.1rem] font-bold text-primary lg:text-[2.5rem]">
+            サロン一覧（ご自宅から近い順）
+          </h1>
+          <p className="text-lg leading-relaxed text-primary/80 lg:text-xl">
+            徒歩や送り迎えがしやすい拠点を優先表示しています。気になるサロンはカード下部のボタンから相談できます。
+          </p>
+        </div>
+        <div className="rounded-[1.75rem] border border-primary/20 bg-white/80 p-5 text-base text-muted-foreground lg:text-lg">
+          <p className="font-semibold text-primary">迷ったときは「電話で予約を相談する」を押してください。</p>
+          <p>スタッフが候補を一緒に整理します。</p>
+        </div>
       </header>
 
-      <section aria-label="サロンカード一覧" className="grid gap-6">
+      <section aria-label="サロンカード一覧" className="flex flex-col gap-8">
         {storeSummaries.map((summary) => (
-          <Card key={summary.store.id} className="border-none bg-card/95 shadow-soft">
-            <CardHeader className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-              <div className="space-y-2">
-                <CardTitle className="text-2xl text-foreground md:text-3xl">
+          <Card
+            key={summary.store.id}
+            className="rounded-[2.25rem] border border-primary/20 bg-card/95 shadow-soft"
+          >
+            <CardHeader className="flex flex-col gap-5">
+              <div className="space-y-3">
+                <CardTitle className="text-2xl text-foreground lg:text-[2.2rem]">
                   {summary.store.name}
                 </CardTitle>
-                <CardDescription className="text-lg text-muted-foreground md:text-xl">
+                <CardDescription className="text-lg text-muted-foreground lg:text-xl">
                   {summary.store.address}
                 </CardDescription>
               </div>
-              <div className="flex flex-col items-start gap-2 md:items-end">
-                <Badge variant={summary.totalUpcoming > 0 ? 'secondary' : 'outline'} className="text-base">
+              <div className="flex flex-col items-start gap-2 text-left">
+                <Badge
+                  variant={summary.totalUpcoming > 0 ? 'secondary' : 'outline'}
+                  className="rounded-full px-4 py-1 text-base lg:text-lg"
+                >
                   {summary.totalUpcoming > 0 ? `空き ${summary.totalUpcoming} 枠` : '次回枠を調整中'}
                 </Badge>
                 {summary.maxCapacity > 0 && (
-                  <p className="text-base text-muted-foreground md:text-lg">
-                    最大 {summary.maxCapacity} 名まで一緒にご利用いただけます
+                  <p className="text-base text-muted-foreground lg:text-lg">
+                    最大 {summary.maxCapacity} 名までご利用いただけます
                   </p>
                 )}
               </div>
             </CardHeader>
-            <CardContent className="grid gap-6 md:grid-cols-[1.2fr_0.8fr]">
-              <div className="space-y-4">
-                <h2 className="text-xl font-semibold text-foreground md:text-2xl">直近の空き枠</h2>
+
+            <CardContent className="flex flex-col gap-6">
+              <div className="space-y-5">
+                <h2 className="text-xl font-semibold text-foreground lg:text-2xl">直近の空き枠</h2>
                 {summary.upcomingSlots.length > 0 ? (
-                  <ol className="space-y-3" aria-label={`${summary.store.name} の空き枠`}>
+                  <ol className="space-y-4" aria-label={`${summary.store.name} の空き枠`}>
                     {summary.upcomingSlots.slice(0, 4).map((slot) => (
                       <li
                         key={slot.id}
-                        className="flex flex-col gap-2 rounded-2xl border-2 border-border bg-muted/30 px-4 py-3"
+                        className="flex flex-col gap-2 rounded-[1.75rem] border border-border/60 bg-muted/40 px-4 py-4"
                       >
-                        <p className="text-lg font-semibold text-foreground md:text-xl">
+                        <p className="text-lg font-semibold text-foreground lg:text-xl">
                           {slotFormatter.format(slot.startAt)} 開始
                         </p>
-                        <p className="text-base text-muted-foreground md:text-lg">
+                        <p className="text-base text-muted-foreground lg:text-lg">
                           終了予定: {timeFormatter.format(slot.endAt)} / 定員 {slot.capacity} 名
                         </p>
                         {slot.title && (
-                          <p className="text-base text-muted-foreground md:text-lg">内容: {slot.title}</p>
+                          <p className="text-base text-muted-foreground lg:text-lg">内容: {slot.title}</p>
                         )}
                       </li>
                     ))}
                     {summary.upcomingSlots.length > 4 && (
-                      <li className="text-base text-muted-foreground md:text-lg">
-                        ほか {summary.upcomingSlots.length - 4} 枠ございます。ゆっくりお選びください。
+                      <li className="text-base text-muted-foreground lg:text-lg">
+                        ほか {summary.upcomingSlots.length - 4} 枠ございます。スタッフが最適な枠をご案内します。
                       </li>
                     )}
                   </ol>
                 ) : (
-                  <p className="text-base text-muted-foreground md:text-lg">
-                    現在次の枠を準備中です。ご希望があればスタッフが優先的にお知らせします。
+                  <p className="text-base text-muted-foreground lg:text-lg">
+                    現在次の枠を準備中です。ご希望の曜日や時間帯を教えていただければ、優先的にご連絡します。
                   </p>
                 )}
               </div>
 
-              <div className="flex flex-col gap-3">
+              <div className="flex flex-col gap-4 rounded-[1.75rem] border border-primary/20 bg-primary/5 p-5">
+                <p className="text-base font-semibold text-primary lg:text-lg">
+                  ボタンを押すとスタッフが順番に対応します。落ち着いてお待ちください。
+                </p>
                 <Button type="button" size="lg" className="w-full justify-center">
                   電話で予約を相談する
                 </Button>
                 <Button type="button" size="lg" variant="outline" className="w-full justify-center">
                   サロンの詳細を聞く
                 </Button>
-                <p className="text-sm text-muted-foreground md:text-base">
-                  ご家族の同席や送迎のご相談も受け付けています。お気軽にお問い合わせください。
-                </p>
+                <p className="text-sm text-muted-foreground lg:text-base">送迎や同席の希望もお伺いします。</p>
               </div>
             </CardContent>
           </Card>
         ))}
+
         {!hasUpcoming && (
-          <div className="rounded-3xl border-2 border-dashed border-border bg-muted/20 px-6 py-8 text-center text-lg text-muted-foreground md:text-xl">
-            現在は予約枠の準備中です。お困りの場合はお電話での相談をご利用ください。（050-1234-5678）
+          <div className="rounded-[2rem] border-2 border-dashed border-border bg-muted/30 px-6 py-10 text-center text-lg text-muted-foreground lg:text-xl">
+            現在は調整中です。お急ぎの方はお電話（050-1234-5678）でご相談ください。
           </div>
         )}
       </section>

--- a/apps/user/src/components/logo.tsx
+++ b/apps/user/src/components/logo.tsx
@@ -2,15 +2,24 @@ import React from 'react';
 
 export function Logo() {
   const name = import.meta.env.VITE_SITE_NAME ?? 'Salon de Morning';
-  const sub = import.meta.env.VITE_BRAND_SUBLABEL_USER ?? '一般ユーザー';
+  const sub = import.meta.env.VITE_BRAND_SUBLABEL_USER ?? '利用者向けポータル';
   return (
-    <div className="inline-flex flex-col gap-1 select-none text-left md:flex-row md:items-end md:gap-3">
-      <span className="text-3xl font-extrabold tracking-tight text-primary drop-shadow-sm md:text-4xl">
+    <div
+      className="inline-flex flex-col gap-3 select-none text-left"
+      role="img"
+      aria-label={`${name} ${sub}`}
+    >
+      <span className="text-4xl font-black tracking-tight text-primary drop-shadow-sm lg:text-5xl">
         {name}
       </span>
-      <span className="rounded-full bg-secondary/60 px-3 py-1 text-sm font-semibold text-secondary-foreground md:text-base">
-        {sub}
-      </span>
+      <div className="flex flex-col gap-2 text-left sm:flex-row sm:items-center sm:gap-3">
+        <span className="w-fit rounded-full bg-secondary/70 px-4 py-1 text-sm font-semibold text-secondary-foreground lg:text-base">
+          {sub}
+        </span>
+        <span className="text-sm font-medium uppercase tracking-[0.16em] text-muted-foreground/90 lg:text-base">
+          朝の安心を、地域の力で
+        </span>
+      </div>
     </div>
   );
 }

--- a/apps/user/src/components/ui/button.tsx
+++ b/apps/user/src/components/ui/button.tsx
@@ -4,9 +4,9 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 rounded-xl font-semibold tracking-wide'
+  'inline-flex items-center justify-center gap-2 rounded-[1.5rem] font-semibold tracking-wide shadow-soft'
     + ' transition-transform transition-shadow duration-200 ease-out focus-visible:outline-none focus-visible:ring-4'
-    + ' focus-visible:ring-ring/60 focus-visible:ring-offset-1 focus-visible:ring-offset-background'
+    + ' focus-visible:ring-ring/60 focus-visible:ring-offset-2 focus-visible:ring-offset-background'
     + ' disabled:pointer-events-none disabled:opacity-60 active:translate-y-[1px]',
   {
     variants: {
@@ -16,7 +16,7 @@ const buttonVariants = cva(
         secondary:
           'bg-secondary text-secondary-foreground shadow-soft hover:-translate-y-0.5 hover:shadow-secondary/30',
         outline:
-          'border-2 border-border bg-transparent text-foreground hover:border-primary hover:text-primary focus-visible:ring-primary/40',
+          'border-2 border-border bg-transparent text-foreground hover:border-primary hover:bg-primary/5 hover:text-primary focus-visible:ring-primary/40',
         ghost: 'bg-transparent text-foreground hover:bg-secondary/40 focus-visible:ring-primary/35',
         link:
           'bg-transparent text-primary underline-offset-4 hover:text-primary/80 hover:underline focus-visible:ring-transparent focus-visible:outline-offset-2',

--- a/apps/user/src/styles.css
+++ b/apps/user/src/styles.css
@@ -4,74 +4,74 @@
 
 @layer base {
   :root {
-    --background: 36 48% 96%;
-    --foreground: 215 28% 16%;
+    --background: 210 40% 97%;
+    --foreground: 215 30% 16%;
 
-    --muted: 200 28% 92%;
-    --muted-foreground: 215 18% 34%;
+    --muted: 206 28% 90%;
+    --muted-foreground: 214 22% 32%;
 
     --popover: 0 0% 100%;
-    --popover-foreground: 215 28% 16%;
+    --popover-foreground: 215 30% 16%;
 
     --card: 0 0% 100%;
-    --card-foreground: 215 28% 16%;
+    --card-foreground: 215 30% 16%;
 
-    --border: 156 24% 78%;
-    --input: 156 24% 78%;
-    --ring: 158 56% 36%;
+    --border: 205 25% 80%;
+    --input: 205 25% 78%;
+    --ring: 204 82% 38%;
 
-    --primary: 158 55% 32%;
-    --primary-foreground: 42 100% 97%;
+    --primary: 204 82% 35%;
+    --primary-foreground: 210 100% 97%;
 
-    --secondary: 189 40% 88%;
-    --secondary-foreground: 196 56% 18%;
+    --secondary: 170 44% 88%;
+    --secondary-foreground: 176 64% 18%;
 
-    --accent: 32 86% 55%;
-    --accent-foreground: 42 100% 98%;
+    --accent: 32 90% 56%;
+    --accent-foreground: 36 100% 98%;
 
-    --destructive: 358 72% 44%;
+    --destructive: 358 70% 45%;
     --destructive-foreground: 0 0% 100%;
 
-    --radius: 1rem;
-    --shadow-soft: 0 24px 48px -28px rgba(28, 68, 54, 0.35);
+    --radius: 1.2rem;
+    --shadow-soft: 0 26px 56px -26px rgba(21, 63, 92, 0.32);
   }
 
   .dark {
-    --background: 215 30% 10%;
-    --foreground: 36 48% 96%;
+    --background: 217 33% 12%;
+    --foreground: 36 48% 92%;
 
-    --muted: 215 22% 22%;
-    --muted-foreground: 36 24% 80%;
+    --muted: 215 22% 24%;
+    --muted-foreground: 36 28% 80%;
 
-    --popover: 215 30% 12%;
-    --popover-foreground: 36 48% 96%;
+    --popover: 217 33% 14%;
+    --popover-foreground: 36 48% 92%;
 
-    --card: 215 30% 12%;
-    --card-foreground: 36 48% 96%;
+    --card: 217 33% 14%;
+    --card-foreground: 36 48% 92%;
 
-    --border: 214 22% 32%;
-    --input: 214 22% 32%;
-    --ring: 158 52% 46%;
+    --border: 216 22% 32%;
+    --input: 216 22% 32%;
+    --ring: 204 86% 48%;
 
-    --primary: 158 55% 42%;
-    --primary-foreground: 36 48% 96%;
+    --primary: 204 82% 46%;
+    --primary-foreground: 210 100% 96%;
 
-    --secondary: 199 36% 26%;
-    --secondary-foreground: 36 48% 96%;
+    --secondary: 174 36% 28%;
+    --secondary-foreground: 36 48% 92%;
 
-    --accent: 32 86% 55%;
-    --accent-foreground: 36 48% 96%;
+    --accent: 32 90% 56%;
+    --accent-foreground: 36 48% 92%;
 
-    --destructive: 358 72% 54%;
-    --destructive-foreground: 36 48% 96%;
+    --destructive: 358 74% 56%;
+    --destructive-foreground: 36 48% 92%;
 
-    --shadow-soft: 0 24px 48px -28px rgba(9, 27, 21, 0.55);
+    --shadow-soft: 0 26px 56px -26px rgba(3, 19, 30, 0.6);
   }
 }
 
 @layer base {
   html {
-    font-size: clamp(18px, 17px + 0.4vw, 21px);
+    font-size: clamp(19px, 18px + 0.45vw, 22px);
     scroll-behavior: smooth;
   }
 
@@ -84,12 +84,12 @@
     font-feature-settings: 'palt' 1;
     @apply bg-background text-foreground antialiased;
     background-image:
-      radial-gradient(140% 80% at 10% 10%, rgba(44, 111, 91, 0.08) 0%, rgba(44, 111, 91, 0) 60%),
-      radial-gradient(120% 80% at 90% 0%, rgba(255, 177, 109, 0.1) 0%, rgba(255, 177, 109, 0) 55%),
-      linear-gradient(180deg, rgba(255, 255, 255, 0.7) 0%, rgba(255, 255, 255, 0) 45%),
+      radial-gradient(180% 100% at 10% 5%, rgba(44, 126, 174, 0.12) 0%, rgba(44, 126, 174, 0) 45%),
+      radial-gradient(120% 70% at 90% 0%, rgba(255, 194, 132, 0.16) 0%, rgba(255, 194, 132, 0) 50%),
+      radial-gradient(150% 120% at 50% 100%, rgba(191, 233, 227, 0.18) 0%, rgba(191, 233, 227, 0) 60%),
       hsl(var(--background));
     min-height: 100%;
-    line-height: 1.7;
+    line-height: 1.75;
   }
 
   h1 {


### PR DESCRIPTION
## 概要
- ユーザー向け画面の冗長なコピーを全面的に整理し、主要情報に集中させました
- サロン・予約画面の注意書きを簡潔化し、必要な案内だけが残るようにしました
- 更新時刻や操作訴求など重複するメッセージを削除し、アクセシビリティ改善と整合させました

## テスト
- pnpm --filter @app/user build